### PR TITLE
`MetaData_Hash_Core_ReloadMemory_MaxPerformance` test stability

### DIFF
--- a/Tests/FiftyOne.DeviceDetection.TestHelpers/Data/MetaDataTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.TestHelpers/Data/MetaDataTests.cs
@@ -41,7 +41,16 @@ namespace FiftyOne.DeviceDetection.TestHelpers.Data
             PerformanceProfiles profile, 
             bool inmemory)
         {
-            if (inmemory) return 800;
+            if (inmemory)
+            {
+                switch (profile)
+                {
+                    case PerformanceProfiles.MaxPerformance:
+                        return 600;
+                    default:
+                        return 800;
+                }
+            }
             switch (profile)
             {
                 case PerformanceProfiles.MaxPerformance:


### PR DESCRIPTION
#### Addressed failure

https://github.com/51Degrees/device-detection-dotnet/actions/runs/6217416523/job/16872477936#step:5:596


#### Changes

- Increase reload frequency for (profile=MaxPerformance, in-memory=true) test case.