### PR TITLE
Restore performance plots

### DIFF
--- a/.github/workflows/nightly-prs-to-main.yml
+++ b/.github/workflows/nightly-prs-to-main.yml
@@ -17,6 +17,7 @@ jobs:
     uses: 51Degrees/common-ci/.github/workflows/nightly-prs-to-main.yml@main
     with:
       repo-name: ${{ github.event.repository.name }}
+      org-name: ${{ github.event.repository.owner.login }}
       dryrun: ${{ inputs.dryrun || false }}
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/nightly-publish-main.yml
+++ b/.github/workflows/nightly-publish-main.yml
@@ -12,6 +12,7 @@ jobs:
     uses: 51Degrees/common-ci/.github/workflows/nightly-publish-main.yml@main
     with:
       repo-name: ${{ github.event.repository.name }}
+      org-name: ${{ github.event.repository.owner.login }}
       build-platform: windows-latest
     secrets: 
       token: ${{ secrets.ACCESS_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "FiftyOne.DeviceDetection.Hash.Engine.OnPremise/device-detection-cxx"]
 	path = FiftyOne.DeviceDetection.Hash.Engine.OnPremise/device-detection-cxx
-	url = https://github.com/51Degrees/device-detection-cxx.git
+	url = ../device-detection-cxx

--- a/ci/run-performance-tests-console.ps1
+++ b/ci/run-performance-tests-console.ps1
@@ -9,7 +9,7 @@ param(
 
 $RepoPath = [IO.Path]::Combine($pwd, $RepoName)
 $PerfResultsFile = [IO.Path]::Combine($RepoPath, "test-results", "performance-summary", "results_$Name.json")
-$EvidenceFiles = [IO.Path]::Combine($pwd, $RepoName,"FiftyOne.DeviceDetection", "device-detection-cxx", "device-detection-data")
+$EvidenceFiles = [IO.Path]::Combine($pwd, $RepoName,"FiftyOne.DeviceDetection.Hash.Engine.OnPremise", "device-detection-cxx", "device-detection-data")
 $ExamplesRepoName = "device-detection-dotnet-examples"
 $ExamplesRepoPath = [IO.Path]::Combine($pwd, $ExamplesRepoName)
 $DeviceDetectionProject = [IO.Path]::Combine($RepoPath, "FiftyOne.DeviceDetection", "FiftyOne.DeviceDetection.csproj")

--- a/ci/run-performance-tests-web.ps1
+++ b/ci/run-performance-tests-web.ps1
@@ -32,6 +32,9 @@ finally {
 
 }
 
+# workaround, see https://github.com/actions/runner-images/issues/8598
+$env:PATH = $env:PATH -replace "C:\\Strawberry\\c\\bin;"
+
 Write-Output "Setting Data File for testing"
 
 $SettingsFile = [IO.Path]::Combine($RepoPath, "performance-tests", "appsettings.json") 


### PR DESCRIPTION
### Changes:

- Add `org-name` to some workflow files.
- Restore submodule URL to relative path.
- Fix `EvidenceFiles` path.
- Add cmake downgrade workaround.