### PR TITLE
Improve `MetaDataTests`

### DIFF
--- a/Tests/FiftyOne.DeviceDetection.TestHelpers/Data/MetaDataTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.TestHelpers/Data/MetaDataTests.cs
@@ -27,7 +27,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/Tests/FiftyOne.DeviceDetection.TestHelpers/Data/MetaDataTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.TestHelpers/Data/MetaDataTests.cs
@@ -153,8 +153,14 @@ namespace FiftyOne.DeviceDetection.TestHelpers.Data
             var refreshResults = reloader.Result;
 
             LogWithTimestamp($"Refreshed the dataset {refreshResults.Count} times.");
-            ValidateResults(HashTaskCount, hashes, refreshResults);
-            DumpLogs();
+            try
+            {
+                ValidateResults(HashTaskCount, hashes, refreshResults);
+            }
+            finally
+            {
+                DumpLogs();
+            }
         }
 
         private void ValidateResults(


### PR DESCRIPTION
### Changes:
- Move the knowledge of `inMemory` flag up out of `Reload` method.
- Defer the actual output of logs to console till test is finished.
- Use `AutoResetEvent` to align `RefreshData` calls with hash task starts.