### PR TITLE
[Re]: Expose DataUpdate[Url,VerifyMd5,UseUrlFormatter] on DeviceDetectionOnPremisePipelineBuilder

### DIFF
--- a/FiftyOne.DeviceDetection/DeviceDetectionOnPremisePipelineBuilder.cs
+++ b/FiftyOne.DeviceDetection/DeviceDetectionOnPremisePipelineBuilder.cs
@@ -54,8 +54,7 @@ namespace FiftyOne.DeviceDetection
         private bool? _dataUpdateOnStartUpEnabled = null;
         private string _dataUpdateUrlString = null;
         private Uri _dataUpdateUrlUri = null;
-        private bool? _useFormatter = null;
-        private IDataUpdateUrlFormatter _dataUpdateUrlFormatter = null;
+        private IList<IDataUpdateUrlFormatter> _dataUpdateUrlFormatter = null;
         private bool? _dataUpdateVerifyMd5 = null;
         private bool? _dataFileSystemWatcherEnabled = null;
         private int? _updatePollingInterval = null;
@@ -466,33 +465,7 @@ namespace FiftyOne.DeviceDetection
         public DeviceDetectionOnPremisePipelineBuilder SetDataUpdateUrlFormatter(
             IDataUpdateUrlFormatter formatter)
         {
-            _dataUpdateUrlFormatter = formatter;
-            _useFormatter = null;
-            return this;
-        }
-
-        /// <summary>
-        /// Enable or disable the <see cref="IDataUpdateUrlFormatter"/>
-        /// to be used when creating the complete URL to request updates
-        /// from.
-        /// </summary>
-        /// <remarks>
-        /// Setting this to false is equivalent to calling 
-        /// <see cref="SetDataUpdateUrlFormatter(IDataUpdateUrlFormatter)"/>
-        /// with a null parameter.
-        /// It is available as a separate method in order to support 
-        /// disabling the formatter from a configuration file.
-        /// </remarks>
-        /// <param name="useFormatter">
-        /// True to use the specified formatter (default). False to
-        /// prevent the specified formatter from being used.
-        /// </param>
-        /// <returns>
-        /// This builder instance.
-        /// </returns>
-        public DeviceDetectionOnPremisePipelineBuilder SetDataUpdateUseUrlFormatter(bool useFormatter)
-        {
-            _useFormatter = useFormatter;
+            _dataUpdateUrlFormatter = new IDataUpdateUrlFormatter[] { formatter };
             return this;
         }
 
@@ -707,13 +680,9 @@ namespace FiftyOne.DeviceDetection
             {
                 builder.SetDataUpdateUrl(_dataUpdateUrlUri);
             }
-            if (_dataUpdateUrlFormatter != null)
+            if (_dataUpdateUrlFormatter != null && _dataUpdateUrlFormatter.Count > 0)
             {
-                builder.SetDataUpdateUrlFormatter(_dataUpdateUrlFormatter);
-            }
-            if (_useFormatter.HasValue)
-            {
-                builder.SetDataUpdateUseUrlFormatter(_useFormatter.Value);
+                builder.SetDataUpdateUrlFormatter(_dataUpdateUrlFormatter[0]);
             }
             if (_dataUpdateVerifyMd5.HasValue)
             {

--- a/FiftyOne.DeviceDetection/DeviceDetectionOnPremisePipelineBuilder.cs
+++ b/FiftyOne.DeviceDetection/DeviceDetectionOnPremisePipelineBuilder.cs
@@ -54,7 +54,12 @@ namespace FiftyOne.DeviceDetection
         private bool? _dataUpdateOnStartUpEnabled = null;
         private string _dataUpdateUrlString = null;
         private Uri _dataUpdateUrlUri = null;
+
+        /// <summary>
+        /// A Nullable box for a single nullable formatter reference.
+        /// </summary>
         private IList<IDataUpdateUrlFormatter> _dataUpdateUrlFormatter = null;
+
         private bool? _dataUpdateVerifyMd5 = null;
         private bool? _dataFileSystemWatcherEnabled = null;
         private int? _updatePollingInterval = null;

--- a/Tests/FiftyOne.DeviceDetection.Tests.Core/DeviceDetectionPipelineBuilderTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.Tests.Core/DeviceDetectionPipelineBuilderTests.cs
@@ -31,11 +31,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http.Headers;
-using static FiftyOne.DeviceDetection.Tests.Core.DeviceDetectionPipelineBuilderTests;
 
 namespace FiftyOne.DeviceDetection.Tests.Core
 {

--- a/Tests/FiftyOne.DeviceDetection.Tests.Core/DeviceDetectionPipelineBuilderTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.Tests.Core/DeviceDetectionPipelineBuilderTests.cs
@@ -198,9 +198,19 @@ namespace FiftyOne.DeviceDetection.Tests.Core
         #endregion
 
 
-        #region XXXXX
+        #region DataUpdateUseUrlFormatter
 
-        // expansion placeholder
+        private static IEnumerable<bool?> PossibleUseUrlFormatterFlags => new bool?[] { null, true, false };
+        private static TestFragment UseUrlFormatterTestFragment(bool? useUrlFormatter) => new TestFragment(
+            $"{nameof(DeviceDetectionOnPremisePipelineBuilder.SetDataUpdateUseUrlFormatter)}({useUrlFormatter})",
+
+            useUrlFormatter.HasValue
+            ? b => b.SetDataUpdateUseUrlFormatter(useUrlFormatter.Value)
+            : b => b,
+
+            (useUrlFormatter ?? true)
+            ? pd => Assert.IsNotNull(pd.DataFileConfig.UrlFormatter)
+            : pd => Assert.IsNull(pd.DataFileConfig.UrlFormatter));
 
         #endregion
 
@@ -213,6 +223,7 @@ namespace FiftyOne.DeviceDetection.Tests.Core
             yield return PossibleShareUsageFlags.Select(ShareUsageTestFragment).ToList();
             yield return PossibleVerifyMD5Flags.Select(VerifyMD5TestFragment).ToList();
             yield return DataUpdateURLCombos().Select(DataUpdateURLTestFragment).ToList();
+            yield return PossibleUseUrlFormatterFlags.Select(UseUrlFormatterTestFragment).ToList();
         }
 
         private static IEnumerable<TestFragment> PickComboFromVariants(IList<IList<TestFragment>> variants, long comboIndex)

--- a/Tests/FiftyOne.DeviceDetection.Tests.Core/DeviceDetectionPipelineBuilderTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.Tests.Core/DeviceDetectionPipelineBuilderTests.cs
@@ -198,19 +198,9 @@ namespace FiftyOne.DeviceDetection.Tests.Core
         #endregion
 
 
-        #region DataUpdateUseUrlFormatter
+        #region DataUpdateURLFormatter
 
-        private static IEnumerable<bool?> PossibleUseUrlFormatterFlags => new bool?[] { null, true, false };
-        private static TestFragment UseUrlFormatterTestFragment(bool? useUrlFormatter) => new TestFragment(
-            $"{nameof(DeviceDetectionOnPremisePipelineBuilder.SetDataUpdateUseUrlFormatter)}({useUrlFormatter})",
-
-            useUrlFormatter.HasValue
-            ? b => b.SetDataUpdateUseUrlFormatter(useUrlFormatter.Value)
-            : b => b,
-
-            (useUrlFormatter ?? true)
-            ? pd => Assert.IsNotNull(pd.DataFileConfig.UrlFormatter)
-            : pd => Assert.IsNull(pd.DataFileConfig.UrlFormatter));
+        // FIXME: Implement
 
         #endregion
 
@@ -223,7 +213,6 @@ namespace FiftyOne.DeviceDetection.Tests.Core
             yield return PossibleShareUsageFlags.Select(ShareUsageTestFragment).ToList();
             yield return PossibleVerifyMD5Flags.Select(VerifyMD5TestFragment).ToList();
             yield return DataUpdateURLCombos().Select(DataUpdateURLTestFragment).ToList();
-            yield return PossibleUseUrlFormatterFlags.Select(UseUrlFormatterTestFragment).ToList();
         }
 
         private static IEnumerable<TestFragment> PickComboFromVariants(IList<IList<TestFragment>> variants, long comboIndex)

--- a/Tests/FiftyOne.DeviceDetection.Tests.Core/DeviceDetectionPipelineBuilderTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.Tests.Core/DeviceDetectionPipelineBuilderTests.cs
@@ -129,7 +129,13 @@ namespace FiftyOne.DeviceDetection.Tests.Core
         #endregion
 
 
-        #region XXXXX
+        #region VerifyMd5
+
+        private static IEnumerable<bool> PossibleVerifyMD5Flags => new bool[] { true, false };
+        private static TestFragment VerifyMD5TestFragment(bool verifyMd5) => new TestFragment(
+            $"{nameof(DeviceDetectionOnPremisePipelineBuilder.SetDataUpdateVerifyMd5)}({verifyMd5})",
+            b => b.SetDataUpdateVerifyMd5(verifyMd5),
+            pd => Assert.AreEqual(verifyMd5, pd.DataFileConfig.VerifyMd5));
 
         #endregion
 
@@ -140,6 +146,7 @@ namespace FiftyOne.DeviceDetection.Tests.Core
             yield return new TestFragment[] { AutoUpdateTestFragment(autoUpdate, licenseKey) };
             yield return new TestFragment[] { TestFragmentForLicenseKey(licenseKey) };
             yield return PossibleShareUsageFlags.Select(ShareUsageTestFragment).ToList();
+            yield return PossibleVerifyMD5Flags.Select(VerifyMD5TestFragment).ToList();
         }
 
         private static IEnumerable<TestFragment> PickComboFromVariants(IList<IList<TestFragment>> variants, long comboIndex)


### PR DESCRIPTION
🗒️ _This supersedes https://github.com/51Degrees/device-detection-dotnet/pull/123 (which was opened from `main` instead of the designated branch)_

### Changes
- Expose data update options on `DeviceDetectionOnPremisePipelineBuilder`.
- Open `DeviceDetectionPipelineBuilder_CheckConfiguration` method for expansion via composition of test fragments.
- Add test fragment for VerifyMd5, SetDataUpdateUrl and DataUpdateUseUrlFormatter.

### Why?
- https://github.com/51Degrees/device-detection-dotnet/issues/121