### PR TITLE
Fix integration tests (part 2)

### DIFF
--- a/ci/run-integration-tests.ps1
+++ b/ci/run-integration-tests.ps1
@@ -11,26 +11,25 @@ param(
 )
 
 $NugetPackageFolder = [IO.Path]::Combine($pwd, "package")
-$EvidenceFiles = [IO.Path]::Combine($pwd, $RepoName,"FiftyOne.DeviceDetection.Hash.Engine.OnPremise", "device-detection-cxx", "device-detection-data")
+$EvidenceFilesSrc = [IO.Path]::Combine($pwd, $RepoName,"FiftyOne.DeviceDetection.Hash.Engine.OnPremise", "device-detection-cxx", "device-detection-data")
 $ExamplesRepoName = "device-detection-dotnet-examples"
 $ExamplesRepoPath = [IO.Path]::Combine($pwd, $ExamplesRepoName)
+$EvidenceFilesDst = [IO.Path]::Combine($ExamplesRepoPath, "device-detection-data")
 
 # If the $Version is empty it means that this script is running in a workflow that will not build packages and integration tests will be skipped.
 if([String]::IsNullOrEmpty($Version) -eq $False) { 
     Write-Output "Cloning '$ExamplesRepoName'"
     ./steps/clone-repo.ps1 -RepoName $ExamplesRepoName -OrgName $OrgName
-    
-    Write-Output "Moving TAC file for examples"
-    $TacFile = [IO.Path]::Combine($EvidenceFiles, "TAC-HashV41.hash") 
-    Copy-Item $TacFile device-detection-dotnet-examples/device-detection-data/TAC-HashV41.hash
 
-    Write-Output "Moving evidence files for examples"
-    $UAFile = [IO.Path]::Combine($EvidenceFiles, "20000 User Agents.csv") 
-    $EvidenceFile = [IO.Path]::Combine($EvidenceFiles, "20000 Evidence Records.yml")
-    Copy-Item $UAFile "device-detection-dotnet-examples/device-detection-data/20000 User Agents.csv"
-    Copy-Item $EvidenceFile "device-detection-dotnet-examples/device-detection-data/20000 Evidence Records.yml"
-    
-    $ExamplesProject = [IO.Path]::Combine($ExamplesRepoPath, "Examples", "ExampleBase")
+    Write-Output "Moving TAC and evidence files for examples..."
+    $EvidenceFileNames = "20000 User Agents.csv", "20000 Evidence Records.yml", "51Degrees-LiteV4.1.hash", "TAC-HashV41.hash"
+    foreach ($NextEvidenceFile in $EvidenceFileNames)
+    {
+        Write-Output "  - Copying $NextEvidenceFile..."
+        $NextEvidenceFileSrc = [IO.Path]::Combine($EvidenceFilesSrc, $NextEvidenceFile)
+        $NextEvidenceFileDst = [IO.Path]::Combine($EvidenceFilesDst, $NextEvidenceFile)
+        Copy-Item $NextEvidenceFileSrc $NextEvidenceFileDst
+    }
     
     # Restore nuget packages in the examples project
     try {
@@ -65,24 +64,34 @@ if([String]::IsNullOrEmpty($Version) -eq $False) {
     
     # Update the dependency in the examples project to point to the newly bulit package
     try{
-        Write-Output "Entering '$ExamplesProject'"
-        Push-Location $ExamplesProject
+        Write-Output "Entering '$ExamplesRepoPath'"
+        Push-Location $ExamplesRepoPath
+
+        Write-Output ""
+        Write-Output "Listing csproj files to update..."
+        Get-ChildItem -Path $ExamplesRepoPath -Recurse -File -Filter "*.csproj" -Name
+        Write-Output ""
 
         # Change the dependency version to the locally build Nuget package
-        Write-Output "Setting the version of the DeviceDetection package to '$Version'"
-        dotnet add package "FiftyOne.DeviceDetection" --version $Version --source "$LocalFeed" 
+        Write-Output "Setting the version of the DeviceDetection package to '$Version'..."
+        Get-ChildItem -Path $ExamplesRepoPath -Recurse -File -Filter "*.csproj" | ForEach-Object {
+            $NextFullName = $_.FullName
+            Write-Output ""
+            Write-Output "Will set the version of the DeviceDetection package to '$Version' in $NextFullName..."
+            dotnet add $NextFullName package "FiftyOne.DeviceDetection" --version $Version --source "$LocalFeed" 
+            Write-Output "Did set the version of the DeviceDetection package to '$Version' in $NextFullName..."
+            Write-Output ""
+        }
+        Write-Output ""
     }
     finally{
-        Write-Output "Leaving '$ExamplesProject'"
+        Write-Output "Leaving '$ExamplesRepoPath'"
         Pop-Location
     }
     
-    # Build and Test Examples project now that all is set up
-    Write-Output "Building project with following configuration '$Configuration|$Arch|$BuildMethod'"
-    ./device-detection-dotnet-examples/ci/build-project.ps1 -RepoName $ExamplesRepoName -Name $Name -Configuration $Configuration -Arch $Arch -BuildMethod $BuildMethod
-    
+    # Test Examples project now that all is set up
     Write-Output "Testing Examples Project"
-    ./dotnet/run-integration-tests.ps1 -RepoName $ExamplesRepoName -ProjectDir $ProjectDir -Name $Name -Configuration $Configuration -Arch $Arch -BuildMethod $BuildMethod -Filter ".*Tests(|\.Web)\.dll"
+    ./dotnet/run-integration-tests.ps1 -RepoName $ExamplesRepoName -ProjectDir $ProjectDir -Name $Name -Configuration $Configuration -Arch $Arch -BuildMethod "dotnet" -DirNameFormatForDotnet "*" -DirNameFormatForNotDotnet "*" -Filter ".*\.sln"
     
     Copy-Item $ExamplesRepoName/test-results $RepoName -Recurse
 } 


### PR DESCRIPTION
⚠️ Depends on https://github.com/51Degrees/common-ci/pull/59

### Changes
- Add "51Degrees-LiteV4.1.hash" to the list of files copied before starting unit tests of examples.
- Add the local package to all `*.csproj` rather than only base one.
- Duplicate testing options (directory name formats and filters) from the examples repository.