### PR TITLE
Test `query-51D-deviceId` is present in `EvidenceKeyFilter`.

### DIFF
--- a/Tests/FiftyOne.DeviceDetection.Hash.Tests/FlowElements/EvidenceKeys.cs
+++ b/Tests/FiftyOne.DeviceDetection.Hash.Tests/FlowElements/EvidenceKeys.cs
@@ -50,6 +50,14 @@ namespace FiftyOne.DeviceDetection.Hash.Tests.FlowElements
 
         [DataTestMethod]
         [DynamicData(nameof(GetPerformanceProfiles), typeof(TestsBase), DynamicDataSourceType.Method)]
+        public void EvidenceKeys_Hash_Core_ContainsQueryParams(PerformanceProfiles profile)
+        {
+            InitWrapperAndUserAgents(profile);
+            EvidenceKeyTests.ContainsQueryParams(Wrapper);
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(GetPerformanceProfiles), typeof(TestsBase), DynamicDataSourceType.Method)]
         public void EvidenceKeys_Hash_Core_ContainsOverrides(PerformanceProfiles profile)
         {
             InitWrapperAndUserAgents(profile);

--- a/Tests/FiftyOne.DeviceDetection.TestHelpers/FlowElements/EvidenceKeyTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.TestHelpers/FlowElements/EvidenceKeyTests.cs
@@ -41,6 +41,7 @@ namespace FiftyOne.DeviceDetection.TestHelpers.FlowElements
         {
             Assert.IsTrue(wrapper.GetEngine().EvidenceKeyFilter.Include("query.user-agent"));
             Assert.IsTrue(wrapper.GetEngine().EvidenceKeyFilter.Include("query.device-stock-ua"));
+            Assert.IsTrue(wrapper.GetEngine().EvidenceKeyFilter.Include("query.51D_deviceId"));
         }
 
         public static void CaseInsensitiveKeys(IWrapper wrapper)


### PR DESCRIPTION
Follows up on https://github.com/51Degrees/device-detection-cxx/pull/73