### PR TITLE
Add Project URL into Nuget package

### DIFF
--- a/FiftyOne.DeviceDetection.Cloud/FiftyOne.DeviceDetection.Cloud.csproj
+++ b/FiftyOne.DeviceDetection.Cloud/FiftyOne.DeviceDetection.Cloud.csproj
@@ -19,7 +19,7 @@
 	  <Copyright>51Degrees Mobile Experts Limited</Copyright>
 	  <PackageTags>51degrees,pipeline,data service,device detection,user-agent,cloud</PackageTags>
 	  <RepositoryUrl>https://github.com/51Degrees/device-detection-dotnet</RepositoryUrl>
-    <PackageProjectUrl>51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <PackageIcon>51d-logo.png</PackageIcon>
     <NeutralLanguage>en</NeutralLanguage>

--- a/FiftyOne.DeviceDetection.Cloud/FiftyOne.DeviceDetection.Cloud.csproj
+++ b/FiftyOne.DeviceDetection.Cloud/FiftyOne.DeviceDetection.Cloud.csproj
@@ -12,12 +12,12 @@
 	  <!-- NuGet package properties -->
 	  <PackageId>FiftyOne.DeviceDetection.Cloud</PackageId>
 	  <Title>Cloud-based device detection service for the 51Degrees Pipeline API</Title>
-    <Description>The 51Degrees Pipeline API provides a fast, modern architecture for consuming real-time digital data services. Device detection will provide detailed information about the hardware and software of devices that are being used to access your website or service.</Description>
+    <Description>51Degrees Device Detection parses HTTP headers to return detailed hardware, operating system, browser, and crawler information for the devices used to access your website or service. This is an alternative to popular UAParser packages.</Description>
 	  <Authors>51Degrees Engineering</Authors>
 	  <PackageLicenseExpression>EUPL-1.2</PackageLicenseExpression>
     <PackageIconUrl>https://51degrees.com/portals/0/Logos/Square%20Logo.png?width=64</PackageIconUrl>
 	  <Copyright>51Degrees Mobile Experts Limited</Copyright>
-	  <PackageTags>51degrees,pipeline,data service,device detection,user-agent,cloud</PackageTags>
+	  <PackageTags>51degrees;pipeline;data;device;detection;user-agent;parse;detection-library;bots;crawler;desktop;tablet;mobile;tv,cloud</PackageTags>
 	  <RepositoryUrl>https://github.com/51Degrees/device-detection-dotnet</RepositoryUrl>
     <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>

--- a/FiftyOne.DeviceDetection.Data/FiftyOne.DeviceDetection.Shared.csproj
+++ b/FiftyOne.DeviceDetection.Data/FiftyOne.DeviceDetection.Shared.csproj
@@ -19,7 +19,7 @@
 	  <Copyright>51Degrees Mobile Experts Limited</Copyright>
 	  <PackageTags>51degrees,pipeline,data service,device detection,user-agent</PackageTags>
 	  <RepositoryUrl>https://github.com/51Degrees/device-detection-dotnet</RepositoryUrl>
-	  <PackageProjectUrl>51degrees.com</PackageProjectUrl>
+	  <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
 	  <RepositoryType>git</RepositoryType>
 	  <PackageIcon>51d-logo.png</PackageIcon>
 	  <NeutralLanguage>en</NeutralLanguage>

--- a/FiftyOne.DeviceDetection.Data/FiftyOne.DeviceDetection.Shared.csproj
+++ b/FiftyOne.DeviceDetection.Data/FiftyOne.DeviceDetection.Shared.csproj
@@ -12,12 +12,12 @@
 	  <!-- NuGet package properties -->
 	  <PackageId>FiftyOne.DeviceDetection.Shared</PackageId>
 	  <Title>Shared code library for device detection services for the 51Degrees Pipeline API</Title>
-	  <Description>The 51Degrees Pipeline API provides a fast, modern architecture for consuming real-time digital data services. Device detection will provide detailed information about the hardware and software of devices that are being used to access your website or service.</Description>
+	  <Description>51Degrees Device Detection parses HTTP headers to return detailed hardware, operating system, browser, and crawler information for the devices used to access your website or service. This is an alternative to popular UAParser packages.</Description>
 	  <Authors>51Degrees Engineering</Authors>
 	  <PackageLicenseExpression>EUPL-1.2</PackageLicenseExpression>
     <PackageIconUrl>https://51degrees.com/portals/0/Logos/Square%20Logo.png?width=64</PackageIconUrl>
 	  <Copyright>51Degrees Mobile Experts Limited</Copyright>
-	  <PackageTags>51degrees,pipeline,data service,device detection,user-agent</PackageTags>
+	  <PackageTags>51degrees;pipeline;data;device;detection;user-agent;parse;detection-library;bots;crawler;desktop;tablet;mobile;tv</PackageTags>
 	  <RepositoryUrl>https://github.com/51Degrees/device-detection-dotnet</RepositoryUrl>
 	  <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
 	  <RepositoryType>git</RepositoryType>

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/FiftyOne.DeviceDetection.Hash.Engine.OnPremise.csproj
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/FiftyOne.DeviceDetection.Hash.Engine.OnPremise.csproj
@@ -19,7 +19,7 @@
 	  <Copyright>51Degrees Mobile Experts Limited</Copyright>
 	  <PackageTags>51degrees,pipeline,data service,device detection,user-agent,hash</PackageTags>
 	  <RepositoryUrl>https://github.com/51Degrees/device-detection-dotnet</RepositoryUrl>
-    <PackageProjectUrl>51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <PackageIcon>51d-logo.png</PackageIcon>
     <NeutralLanguage>en</NeutralLanguage>

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/FiftyOne.DeviceDetection.Hash.Engine.OnPremise.csproj
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/FiftyOne.DeviceDetection.Hash.Engine.OnPremise.csproj
@@ -12,12 +12,12 @@
 	  <!-- NuGet package properties -->
 	  <PackageId>FiftyOne.DeviceDetection.Hash.Engine.OnPremise</PackageId>
 	  <Title>On-premise device detection service for the 51Degrees Pipeline API</Title>
-    <Description>The 51Degrees Pipeline API provides a fast, modern architecture for consuming real-time digital data services. Device detection will provide detailed information about the hardware and software of devices that are being used to access your website or service.</Description>
+    <Description>51Degrees Device Detection parses HTTP headers to return detailed hardware, operating system, browser, and crawler information for the devices used to access your website or service. This is an alternative to popular UAParser packages.</Description>
 	  <Authors>51Degrees Engineering</Authors>
 	  <PackageLicenseExpression>EUPL-1.2</PackageLicenseExpression>
     <PackageIconUrl>https://51degrees.com/portals/0/Logos/Square%20Logo.png?width=64</PackageIconUrl>
 	  <Copyright>51Degrees Mobile Experts Limited</Copyright>
-	  <PackageTags>51degrees,pipeline,data service,device detection,user-agent,hash</PackageTags>
+	  <PackageTags>51degrees;pipeline;data;device;detection;user-agent;parse;detection-library;bots;crawler;desktop;tablet;mobile;tv,hash</PackageTags>
 	  <RepositoryUrl>https://github.com/51Degrees/device-detection-dotnet</RepositoryUrl>
     <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>

--- a/FiftyOne.DeviceDetection/FiftyOne.DeviceDetection.csproj
+++ b/FiftyOne.DeviceDetection/FiftyOne.DeviceDetection.csproj
@@ -19,7 +19,7 @@
 	  <Copyright>51Degrees Mobile Experts Limited</Copyright>
 	  <PackageTags>51degrees,pipeline,data service,device detection,user-agent</PackageTags>
 	  <RepositoryUrl>https://github.com/51Degrees/device-detection-dotnet</RepositoryUrl>
-    <PackageProjectUrl>51degrees.com</PackageProjectUrl>
+    <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <NeutralLanguage>en</NeutralLanguage>
 	  <PackageIcon>51d-logo.png</PackageIcon>

--- a/FiftyOne.DeviceDetection/FiftyOne.DeviceDetection.csproj
+++ b/FiftyOne.DeviceDetection/FiftyOne.DeviceDetection.csproj
@@ -12,12 +12,12 @@
 	  <!-- NuGet package properties -->
 	  <PackageId>FiftyOne.DeviceDetection</PackageId>
 	  <Title>Device detection service for the 51Degrees Pipeline API</Title>
-    <Description>The 51Degrees Pipeline API provides a fast, modern architecture for consuming real-time digital data services. Device detection will provide detailed information about the hardware and software of devices that are being used to access your website or service.</Description>
+    <Description>51Degrees Device Detection parses HTTP headers to return detailed hardware, operating system, browser, and crawler information for the devices used to access your website or service. This is an alternative to popular UAParser packages.</Description>
 	  <Authors>51Degrees Engineering</Authors>
 	  <PackageLicenseExpression>EUPL-1.2</PackageLicenseExpression>
     <PackageIconUrl>https://51degrees.com/portals/0/Logos/Square%20Logo.png?width=64</PackageIconUrl>
 	  <Copyright>51Degrees Mobile Experts Limited</Copyright>
-	  <PackageTags>51degrees,pipeline,data service,device detection,user-agent</PackageTags>
+	  <PackageTags>51degrees;pipeline;data;device;detection;user-agent;parse;detection-library;bots;crawler;desktop;tablet;mobile;tv</PackageTags>
 	  <RepositoryUrl>https://github.com/51Degrees/device-detection-dotnet</RepositoryUrl>
     <PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
### Changes
- Set `PackageProjectUrl` to `https://51degrees.com`.

### Why
- https://github.com/51Degrees/device-detection-dotnet/issues/169