### PR TITLE
Remove `encodedValue` from `ExceptionUachJsUnexpectedFormat`.

### DIFF
--- a/FiftyOne.DeviceDetection/Messages.Designer.cs
+++ b/FiftyOne.DeviceDetection/Messages.Designer.cs
@@ -88,7 +88,7 @@ namespace FiftyOne.DeviceDetection {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Evidence value for key &apos;{0}&apos; is not in the expected format. This should be a base 64 encoded JSON string from a JavaScript call to navigator.userAgentData.getHighEntropyValues. Supplied value was &apos;{1}&apos;.
+        ///   Looks up a localized string similar to Evidence value for key &apos;{0}&apos; is not in the expected format. This should be a base 64 encoded JSON string from a JavaScript call to navigator.userAgentData.getHighEntropyValues..
         /// </summary>
         internal static string ExceptionUachJsUnexpectedFormat {
             get {

--- a/FiftyOne.DeviceDetection/Messages.resx
+++ b/FiftyOne.DeviceDetection/Messages.resx
@@ -127,7 +127,7 @@
     <value>No source for engine data. Use SetFilename or SetEngineData to configure this.</value>
   </data>
   <data name="ExceptionUachJsUnexpectedFormat" xml:space="preserve">
-    <value>Evidence value for key '{0}' is not in the expected format. This should be a base 64 encoded JSON string from a JavaScript call to navigator.userAgentData.getHighEntropyValues. Supplied value was '{1}'</value>
+    <value>Evidence value for key '{0}' is not in the expected format. This should be a base 64 encoded JSON string from a JavaScript call to navigator.userAgentData.getHighEntropyValues.</value>
   </data>
   <data name="ExceptionUnrecognizedFileExtension" xml:space="preserve">
     <value>Unrecognized filename '{0}'. Expected a '*.hash' Hash data file.</value>

--- a/FiftyOne.DeviceDetection/Uach/UachJsConversionElement.cs
+++ b/FiftyOne.DeviceDetection/Uach/UachJsConversionElement.cs
@@ -111,9 +111,9 @@ namespace FiftyOne.DeviceDetection.Uach
                     uachData = JsonConvert.DeserializeObject<UachJson>(decodedValue);
                 }
                 catch (FormatException)
-                { ThrowException(usedEvidenceKey, encodedValue); }
+                { ThrowException(usedEvidenceKey); }
                 catch (JsonReaderException)
-                { ThrowException(usedEvidenceKey, encodedValue); }
+                { ThrowException(usedEvidenceKey); }
 
                 if (uachData != null)
                 {
@@ -161,7 +161,7 @@ namespace FiftyOne.DeviceDetection.Uach
 
                     if (evidenceAdded == false)
                     {
-                        ThrowException(usedEvidenceKey, encodedValue);
+                        ThrowException(usedEvidenceKey);
                     }
                 }
             }
@@ -173,14 +173,11 @@ namespace FiftyOne.DeviceDetection.Uach
         /// <param name="usedEvidenceKey">
         /// The key of the evidence value that was processed
         /// </param>
-        /// <param name="encodedValue">
-        /// The raw value from evidence
-        /// </param>
-        private static void ThrowException(string usedEvidenceKey, string encodedValue)
+        private static void ThrowException(string usedEvidenceKey)
         {
             throw new PipelineException(string.Format(
                 System.Globalization.CultureInfo.InvariantCulture,
-                Messages.ExceptionUachJsUnexpectedFormat, usedEvidenceKey, encodedValue));
+                Messages.ExceptionUachJsUnexpectedFormat, usedEvidenceKey));
         }
 
         /// <summary>


### PR DESCRIPTION
### Why:
- https://github.com/51Degrees/device-detection-dotnet/issues/191