### PR TITLE
Use `macos-12`

### DIFF
--- a/FiftyOne.DeviceDetection.Cloud/FiftyOne.DeviceDetection.Cloud.csproj
+++ b/FiftyOne.DeviceDetection.Cloud/FiftyOne.DeviceDetection.Cloud.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FiftyOne.Pipeline.CloudRequestEngine" Version="4.4.81" />
+    <PackageReference Include="FiftyOne.Pipeline.CloudRequestEngine" Version="4.4.82" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FiftyOne.DeviceDetection.Data/FiftyOne.DeviceDetection.Shared.csproj
+++ b/FiftyOne.DeviceDetection.Data/FiftyOne.DeviceDetection.Shared.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="FiftyOne.Pipeline.Engines.FiftyOne" Version="4.4.81" />
+    <PackageReference Include="FiftyOne.Pipeline.Engines.FiftyOne" Version="4.4.82" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Tests/FiftyOne.DeviceDetection.Cloud.Tests/FiftyOne.DeviceDetection.Cloud.Tests.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Cloud.Tests/FiftyOne.DeviceDetection.Cloud.Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="FiftyOne.Common.TestHelpers" Version="4.4.16" />
-    <PackageReference Include="FiftyOne.Pipeline.Engines.TestHelpers" Version="4.4.81" />
-    <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.81" />
+    <PackageReference Include="FiftyOne.Pipeline.Engines.TestHelpers" Version="4.4.82" />
+    <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.82" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.20.70" />

--- a/Tools/GenerateConfig/GenerateConfig.csproj
+++ b/Tools/GenerateConfig/GenerateConfig.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.81" />
+    <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.82" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ci/options.json
+++ b/ci/options.json
@@ -47,14 +47,14 @@
         "BuildMethod": "dotnet"
     },
     {
-        "Image": "macos-latest",
+        "Image": "macos-12",
         "Name": "Mac_x64_Debug",
         "Configuration": "Debug",
         "Arch": "x64",
         "BuildMethod": "dotnet"
     },
     {
-        "Image": "macos-latest",
+        "Image": "macos-12",
         "Name": "Mac_x64_Release",
         "Configuration": "Release",
         "Arch": "x64",

--- a/performance-tests/performance-tests.csproj
+++ b/performance-tests/performance-tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.81" />
+    <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.82" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.29" />
   </ItemGroup>
 


### PR DESCRIPTION
### Changes
- Switch from `macos-latest` (now 14) to `macos-12`
- Include changes from [nightly-package-update](https://github.com/51Degrees/device-detection-dotnet/tree/nightly-package-update) branch.