### PR TITLE
FEAT/REF: Use PopluateFrom instead of the now obsolete method PopulateFromDictionary

### DIFF
--- a/FiftyOne.DeviceDetection.Cloud/FiftyOne.DeviceDetection.Cloud.csproj
+++ b/FiftyOne.DeviceDetection.Cloud/FiftyOne.DeviceDetection.Cloud.csproj
@@ -66,7 +66,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FiftyOne.Pipeline.CloudRequestEngine" Version="4.4.115" />
+    <PackageReference Include="FiftyOne.Pipeline.CloudRequestEngine" Version="4.4.119" />
     <PackageReference Include="System.Text.Json" Version="6.0.11" />
   </ItemGroup>
 

--- a/FiftyOne.DeviceDetection.Cloud/FlowElements/DeviceDetectionCloudEngine.cs
+++ b/FiftyOne.DeviceDetection.Cloud/FlowElements/DeviceDetectionCloudEngine.cs
@@ -113,7 +113,7 @@ namespace FiftyOne.DeviceDetection.Cloud.FlowElements
                 });
 
             var device = CreateAPVDictionary(propertyValues, Properties.ToList());
-            aspectData.PopulateFromDictionary(device);
+            aspectData.PopulateFrom(device);
         }
 
         protected override Type GetPropertyType(

--- a/FiftyOne.DeviceDetection.Data/Data/DeviceDataBaseOnPremise.cs
+++ b/FiftyOne.DeviceDetection.Data/Data/DeviceDataBaseOnPremise.cs
@@ -366,7 +366,7 @@ namespace FiftyOne.DeviceDetection.Shared.Data
                                     $"type {property.Type.Name}");
                             }
                         };
-                        PopulateFromDictionary(dict);
+                        PopulateFrom(dict);
                         _dictionaryPopulated = true;
                     }
                 }

--- a/FiftyOne.DeviceDetection.Data/FiftyOne.DeviceDetection.Shared.csproj
+++ b/FiftyOne.DeviceDetection.Data/FiftyOne.DeviceDetection.Shared.csproj
@@ -62,7 +62,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="FiftyOne.Pipeline.Engines.FiftyOne" Version="4.4.116" />
+    <PackageReference Include="FiftyOne.Pipeline.Engines.FiftyOne" Version="4.4.119" />
   </ItemGroup>
 
 </Project>

--- a/Tests/FiftyOne.DeviceDetection.Cloud.Tests/FiftyOne.DeviceDetection.Cloud.Tests.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Cloud.Tests/FiftyOne.DeviceDetection.Cloud.Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="FiftyOne.Common.TestHelpers" Version="4.4.21" />
-    <PackageReference Include="FiftyOne.Pipeline.Engines.TestHelpers" Version="4.4.116" />
-    <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.116" />
+    <PackageReference Include="FiftyOne.Pipeline.Engines.TestHelpers" Version="4.4.119" />
+    <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.119" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">

--- a/Tools/GenerateConfig/GenerateConfig.csproj
+++ b/Tools/GenerateConfig/GenerateConfig.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.116" />
+    <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.119" />
     <PackageReference Include="System.Text.Json" Version="6.0.11" />
   </ItemGroup>
 

--- a/performance-tests/performance-tests.csproj
+++ b/performance-tests/performance-tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.116" />
+    <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.4.119" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.36" />
   </ItemGroup>
 


### PR DESCRIPTION
Update Pipeline packages & Use PopluateFrom instead of the now obsolete method PopulateFromDictionary