### PR TITLE
build osx-arm64 package on arm64 runner

### DIFF
--- a/ci/build-package-requirements.ps1
+++ b/ci/build-package-requirements.ps1
@@ -33,21 +33,13 @@ elseif ($IsWindows) {
 }
 elseif ($IsMacOS) {
     $Subfolder = "macos"
-    $Archs = @("x64", "ARM64")
-    foreach($a in $Archs){
-        $ExtraArgs = ""
-        if ($a -eq "ARM64") {
-            $ExtraArgs += " -DCMAKE_OSX_ARCHITECTURES=arm64"
-            $ExtraArgs += " -DBUILD_TESTING=OFF"
-        }
-        ./cxx/build-project.ps1 -RepoName $RepoName -ProjectDir $ProjectDir -Configuration "Release" -ExtraArgs $ExtraArgs -Arch $a
-        $PackageFolder = "package-files/$SubFolder/$a"
-        New-Item -Path $PackageFolder -ItemType Directory -Force
-        Copy-Item -Path $NativeFile -Destination "$PackageFolder/$NativeName" -Force
-        
-        # CMake generates build files specific to the architecture. We are deleting the build folder to ensure clean build enviroment. 
-        Remove-Item -LiteralPath "$RepoPath/$ProjectDir/build" -Force -Recurse -ErrorAction SilentlyContinue
-    }
+    ./cxx/build-project.ps1 -RepoName $RepoName -ProjectDir $ProjectDir -Configuration "Release" -Arch $Arch
+    $PackageFolder = "package-files/$SubFolder/$Arch"
+    New-Item -Path $PackageFolder -ItemType Directory -Force
+    Copy-Item -Path $NativeFile -Destination "$PackageFolder/$NativeName" -Force
+    
+    # CMake generates build files specific to the architecture. We are deleting the build folder to ensure clean build enviroment. 
+    Remove-Item -LiteralPath "$RepoPath/$ProjectDir/build" -Force -Recurse -ErrorAction SilentlyContinue
 }
 else {
     Write-Host "Unsupported OS."

--- a/ci/run-integration-tests.ps1
+++ b/ci/run-integration-tests.ps1
@@ -37,6 +37,7 @@ if([String]::IsNullOrEmpty($Version) -eq $False) {
         Push-Location $ExamplesRepoPath
 
         Write-Output "Running Nuget Restore"
+        dotnet nuget list source
         nuget restore
     }
     finally {
@@ -46,15 +47,15 @@ if([String]::IsNullOrEmpty($Version) -eq $False) {
     }
     
     $LocalFeed = [IO.Path]::Combine($Home, ".nuget", "packages")
-    
+
     # Install the nuget packages to the local feed. 
     # The packages in the 'package' folder must be pushed to local feed and cannot be used directly,
     # as all the other dependencies will already be installed in the local feed.
     try{
         Write-Output "Entering '$NugetPackageFolder' folder"
         Push-Location "$NugetPackageFolder"
-        
         Write-Output "Pushing nuget packages to the local feed"
+        dotnet nuget add source "$LocalFeed"
         dotnet nuget push "*.nupkg" -s "$LocalFeed"
     }
     finally{
@@ -78,7 +79,7 @@ if([String]::IsNullOrEmpty($Version) -eq $False) {
             $NextFullName = $_.FullName
             Write-Output ""
             Write-Output "Will set the version of the DeviceDetection package to '$Version' in $NextFullName..."
-            dotnet add $NextFullName package "FiftyOne.DeviceDetection" --version $Version --source "$LocalFeed" 
+            dotnet add $NextFullName package "FiftyOne.DeviceDetection" --version $Version
             Write-Output "Did set the version of the DeviceDetection package to '$Version' in $NextFullName..."
             Write-Output ""
         }


### PR DESCRIPTION
addresses #349 
* simplify `ci/build-package-requirements.ps1`: build a distinct architecture per runner
* make sure the correct package is added and tested against in `ci/run-integration-tests.ps1`, because previously `--source` was specified and it would not find the matching versions of the dependencies and thus would not update a package reference and thus would not test against a correct package - it would take some packge from nuget, not the one we are about to release 