### PR TITLE
Revert #379 "add special evidence to the evidence key filter"

### DIFF
--- a/FiftyOne.DeviceDetection.Data/Constants.cs
+++ b/FiftyOne.DeviceDetection.Data/Constants.cs
@@ -172,22 +172,5 @@ namespace FiftyOne.DeviceDetection.Shared
             Pipeline.Core.Constants.EVIDENCE_HTTPHEADER_PREFIX +
             Pipeline.Core.Constants.EVIDENCE_SEPERATOR +
             EVIDENCE_SECCHUA_PLATFORM_VERSION_SUFFIX;
-        
-        private const string ghev = "gethighentropyvalues";
-        public const string EVIDENCE_COOKIE_GHEV =
-            Pipeline.Core.Constants.EVIDENCE_COOKIE_PREFIX +
-            Pipeline.Core.Constants.EVIDENCE_SEPERATOR +
-        Pipeline.Engines.Constants.FIFTYONE_COOKIE_PREFIX + ghev;
-        public const string EVIDENCE_QUERY_GHEV = Pipeline.Core.Constants.EVIDENCE_QUERY_PREFIX +
-        Pipeline.Core.Constants.EVIDENCE_SEPERATOR +
-        Pipeline.Engines.Constants.FIFTYONE_COOKIE_PREFIX + ghev;
-
-        private const string sua = "structureduseragent";
-        public const string EVIDENCE_COOKIE_SUA = Pipeline.Core.Constants.EVIDENCE_COOKIE_PREFIX +
-        Pipeline.Core.Constants.EVIDENCE_SEPERATOR +
-        Pipeline.Engines.Constants.FIFTYONE_COOKIE_PREFIX + sua;
-        public const string EVIDENCE_QUERY_SUA = Pipeline.Core.Constants.EVIDENCE_QUERY_PREFIX +
-        Pipeline.Core.Constants.EVIDENCE_SEPERATOR +
-        Pipeline.Engines.Constants.FIFTYONE_COOKIE_PREFIX + sua;
     }
 }

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/FlowElements/DeviceDetectionHashEngine.cs
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/FlowElements/DeviceDetectionHashEngine.cs
@@ -394,16 +394,8 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.FlowElements
         /// </summary>
         private void InitEngineMetaData()
         {
-            var keyList = new List<string>(_engine.getKeys())
-            {
-                Shared.Constants.EVIDENCE_QUERY_GHEV,
-                Shared.Constants.EVIDENCE_QUERY_SUA,
-                Shared.Constants.EVIDENCE_COOKIE_GHEV,
-                Shared.Constants.EVIDENCE_COOKIE_SUA
-            };
-
             _evidenceKeyFilter = new EvidenceKeyFilterWhitelist(
-                keyList,
+                new List<string>(_engine.getKeys()),
                 StringComparer.InvariantCultureIgnoreCase);
             
             _properties = ConstructProperties();

--- a/Tests/FiftyOne.DeviceDetection.Hash.Tests/FlowElements/EngineTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.Hash.Tests/FlowElements/EngineTests.cs
@@ -33,7 +33,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Interop;
 using FiftyOne.Pipeline.Core.Data;
-using Constants = FiftyOne.DeviceDetection.Shared.Constants;
 
 namespace FiftyOne.DeviceDetection.Hash.Tests.FlowElements
 {
@@ -177,26 +176,6 @@ namespace FiftyOne.DeviceDetection.Hash.Tests.FlowElements
             Assert.AreEqual(result3["sec-ch-ua-full-version-list"], "\"Chromium\";v=\"128.0.6613.84\", \"Not;A=Brand\";v=\"24.0.0.0\", \"Google Chrome\";v=\"128.0.6613.84\"");
             Assert.AreEqual(result3["sec-ch-ua-platform"], "\"macOS\"");
             Assert.AreEqual(result3["sec-ch-ua-mobile"], "?0");
-        }
-
-        [TestMethod]
-        public void TestHardcodedEvidenceKeyFilterKeys()
-        {
-            InitWrapperAndUserAgents(PerformanceProfiles.MaxPerformance);
-
-            Assert.IsTrue(Wrapper.Engine.EvidenceKeyFilter.Include(Constants.EVIDENCE_QUERY_GHEV));
-            Assert.IsTrue(Wrapper.Engine.EvidenceKeyFilter.Include(Constants.EVIDENCE_QUERY_SUA));
-            Assert.IsTrue(Wrapper.Engine.EvidenceKeyFilter.Include(Constants.EVIDENCE_COOKIE_GHEV));
-            Assert.IsTrue(Wrapper.Engine.EvidenceKeyFilter.Include(Constants.EVIDENCE_COOKIE_SUA));
-
-            //just in case also testing spelled out variant of the constants:
-            Assert.IsTrue(Wrapper.Engine.EvidenceKeyFilter.Include("query.51d_gethighentropyvalues"));
-            Assert.IsTrue(Wrapper.Engine.EvidenceKeyFilter.Include("query.51d_structureduseragent"));
-            Assert.IsTrue(Wrapper.Engine.EvidenceKeyFilter.Include("cookie.51d_gethighentropyvalues"));
-            Assert.IsTrue(Wrapper.Engine.EvidenceKeyFilter.Include("cookie.51d_structureduseragent"));
-            
-            Assert.IsTrue(Wrapper.Engine.EvidenceKeyFilter.Include("header.user-agent"));
-            Assert.IsFalse(Wrapper.Engine.EvidenceKeyFilter.Include("header.nonexistant"));
         }
     }
 }


### PR DESCRIPTION
### Changes

- Removes hard-coded keys and related tests.

### Why

- https://github.com/51Degrees/device-detection-cxx/pull/195

### Related

- Supersedes https://github.com/51Degrees/device-detection-dotnet/pull/415

### Test runs

- ✅ https://github.com/postindustria-tech/device-detection-dotnet/actions/runs/13205096786