### PR TITLE
Prevent wrong-platform native DLL from overriding Linux publish output

### DIFF
--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/FiftyOne.DeviceDetection.Hash.Engine.OnPremise.csproj
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/FiftyOne.DeviceDetection.Hash.Engine.OnPremise.csproj
@@ -47,6 +47,16 @@
     <BuildType>Release</BuildType>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <_DirectPackRuntimePlatform Condition="'$(Platform)' == 'x64'">x64</_DirectPackRuntimePlatform>
+    <_DirectPackRuntimePlatform Condition="'$(Platform)' == 'x86'">x86</_DirectPackRuntimePlatform>
+    <_DirectPackRuntimePlatform Condition="'$(Platform)' == 'ARM64'">arm64</_DirectPackRuntimePlatform>
+
+    <_DirectPackRuntimeIdentifier Condition="$([MSBuild]::IsOsPlatform('Windows')) AND '$(_DirectPackRuntimePlatform)' != ''">win-$(_DirectPackRuntimePlatform)</_DirectPackRuntimeIdentifier>
+    <_DirectPackRuntimeIdentifier Condition="$([MSBuild]::IsOsPlatform('Linux')) AND '$(_DirectPackRuntimePlatform)' != ''">linux-$(_DirectPackRuntimePlatform)</_DirectPackRuntimeIdentifier>
+    <_DirectPackRuntimeIdentifier Condition="$([MSBuild]::IsOsPlatform('OSX')) AND '$(_DirectPackRuntimePlatform)' != ''">osx-$(_DirectPackRuntimePlatform)</_DirectPackRuntimeIdentifier>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="build\**" />
     <Compile Remove="device-detection-cxx\**" />
@@ -132,20 +142,29 @@
     </_PackageFiles>
 
     <!-- Direct pack -->
-    <!-- Copy the Windows x86/x64 native DLL -->
-    <_PackageFiles Include="$(OutputPath)\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll" Condition="$([MSBuild]::IsOsPlatform('Windows')) AND !$(BuiltOnCI)">
+    <_PackageFiles Include="..\windows\x64\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll" Condition="!$(BuiltOnCI) and Exists('..\windows\x64\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll')">
       <BuildAction>None</BuildAction>
-      <PackagePath>runtimes\win-x$(Platform)\native</PackagePath>
+      <PackagePath>runtimes\win-x64\native</PackagePath>
     </_PackageFiles>
-    <!-- Copy the Linux x86/x64 native DLL -->
-    <_PackageFiles Include="$(OutputPath)\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll" Condition="$([MSBuild]::IsOsPlatform('Linux')) AND !$(BuiltOnCI)">
+    <_PackageFiles Include="..\windows\x86\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll" Condition="!$(BuiltOnCI) and Exists('..\windows\x86\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll')">
       <BuildAction>None</BuildAction>
-      <PackagePath>runtimes\linux-$(Platform)\native</PackagePath>
+      <PackagePath>runtimes\win-x86\native</PackagePath>
     </_PackageFiles>
-    <!-- Copy the Mac x64/arm64 native DLL -->
-    <_PackageFiles Include="$(OutputPath)\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll" Condition="$([MSBuild]::IsOsPlatform('OSX')) AND !$(BuiltOnCI)">
+    <_PackageFiles Include="..\linux\x64\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll" Condition="!$(BuiltOnCI) and Exists('..\linux\x64\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll')">
       <BuildAction>None</BuildAction>
-      <PackagePath>runtimes\osx-$(Platform)\native</PackagePath>
+      <PackagePath>runtimes\linux-x64\native</PackagePath>
+    </_PackageFiles>
+    <_PackageFiles Include="..\linux\arm64\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll" Condition="!$(BuiltOnCI) and Exists('..\linux\arm64\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll')">
+      <BuildAction>None</BuildAction>
+      <PackagePath>runtimes\linux-arm64\native</PackagePath>
+    </_PackageFiles>
+    <_PackageFiles Include="..\macos\x64\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll" Condition="!$(BuiltOnCI) and Exists('..\macos\x64\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll')">
+      <BuildAction>None</BuildAction>
+      <PackagePath>runtimes\osx-x64\native</PackagePath>
+    </_PackageFiles>
+    <_PackageFiles Include="..\macos\arm64\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll" Condition="!$(BuiltOnCI) and Exists('..\macos\arm64\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll')">
+      <BuildAction>None</BuildAction>
+      <PackagePath>runtimes\osx-arm64\native</PackagePath>
     </_PackageFiles>
   </ItemGroup>
   <ItemGroup>

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/FiftyOne.DeviceDetection.Hash.Engine.OnPremise.targets
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/FiftyOne.DeviceDetection.Hash.Engine.OnPremise.targets
@@ -14,7 +14,11 @@
     <_FiftyOneNativeAssetPath Condition="'$(_FiftyOneNativeRuntime)' != ''">$(MSBuildThisFileDirectory)..\runtimes\$(_FiftyOneNativeRuntime)\native\$(_FiftyOneNativeAssetName)</_FiftyOneNativeAssetPath>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(_FiftyOneNativeAssetPath)' != '' and Exists('$(_FiftyOneNativeAssetPath)')">
+  <!-- SDK-style projects (.NET Core / .NET 5+) resolve native assets automatically via the
+       runtimes/ folder in the NuGet package — no manual copy needed, and attempting one
+       would overwrite the correctly-resolved platform binary with a wrong one.
+       Only activate this copy for legacy .NET Framework consumers. -->
+  <ItemGroup Condition="'$(_FiftyOneNativeAssetPath)' != '' and Exists('$(_FiftyOneNativeAssetPath)') and '$(UsingMicrosoftNETSdk)' != 'true'">
     <None Include="$(_FiftyOneNativeAssetPath)">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>$(_FiftyOneNativeAssetName)</Link>

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/FiftyOne.DeviceDetection.Hash.Engine.OnPremise.targets
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/FiftyOne.DeviceDetection.Hash.Engine.OnPremise.targets
@@ -1,27 +1,23 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- Ensure that for Framework projects the correct DLL is copied to the build directory -->
-  
-  <!-- If the build is for AnyCPU, then assume x64 and copy to the root of the bin directory -->
-  <ItemGroup Condition=" '$(Platform)' == 'AnyCPU' ">
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll">
+  <PropertyGroup>
+    <_FiftyOneNativeAssetName>FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll</_FiftyOneNativeAssetName>
+
+    <!-- Prefer the runtime identifier when one is available. -->
+    <_FiftyOneNativeRuntime Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</_FiftyOneNativeRuntime>
+
+    <!-- Fall back to the legacy Windows platform mapping when no RID is set. -->
+    <_FiftyOneNativeRuntime Condition="'$(_FiftyOneNativeRuntime)' == '' and '$(Platform)' == 'x86'">win-x86</_FiftyOneNativeRuntime>
+    <_FiftyOneNativeRuntime Condition="'$(_FiftyOneNativeRuntime)' == '' and ('$(Platform)' == 'x64' or '$(Platform)' == 'AnyCPU' or '$(Platform)' == '')">win-x64</_FiftyOneNativeRuntime>
+
+    <_FiftyOneNativeAssetPath Condition="'$(_FiftyOneNativeRuntime)' != ''">$(MSBuildThisFileDirectory)..\runtimes\$(_FiftyOneNativeRuntime)\native\$(_FiftyOneNativeAssetName)</_FiftyOneNativeAssetPath>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(_FiftyOneNativeAssetPath)' != '' and Exists('$(_FiftyOneNativeAssetPath)')">
+    <None Include="$(_FiftyOneNativeAssetPath)">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll</Link>
-    </None>
-  </ItemGroup>
-  <!-- If the build is for x64, copy to the root of the bin directory -->
-  <ItemGroup Condition=" '$(Platform)' == 'x64' ">
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll</Link>
-    </None>
-  </ItemGroup>
-  <!-- If the build is for x86, copy to the root of the bin directory -->
-  <ItemGroup Condition=" '$(Platform)' == 'x86' ">
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x86\native\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll</Link>
+      <Link>$(_FiftyOneNativeAssetName)</Link>
     </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Problem

`dotnet publish -r linux-x64` produced a Windows PE32+ DLL instead of a Linux ELF binary.

The package's .targets file used hard-coded `<ItemGroup>` blocks that always copied `runtimes/win-x64/native/` into every SDK project's `bin/` output. SDK-style projects don't need this - NuGet resolves the correct `runtimes/{rid}/native/` binary automatically at publish time. The forced copy overwrote the correct Linux binary with a Windows one before the publish collector ran.

###  Changes

`.targets` two fixes:
1. Replace three Platform-keyed `<ItemGroup>` blocks with a single <PropertyGroup> that prefers `$(RuntimeIdentifier)` and falls back to a `Platform → RID` mapping.
2. Add `'$(UsingMicrosoftNETSdk)' != 'true'` to the `<ItemGroup>` condition. The manual copy is only needed for legacy .NET Framework consumers; SDK-style projects get native assets resolved automatically, and the copy was actively breaking cross-platform publishing.

.csproj direct-pack - fix broken paths in the `!$(BuiltOnCI)` pack items:

####  Reproduce (Linux / WSL)

```
  mkdir /tmp/repro && cd /tmp/repro
  dotnet new console
  dotnet add package FiftyOne.DeviceDetection.Hash.Engine.OnPremise --version 4.5.62  # pre-fix
  dotnet publish -r linux-x64 -c Release --self-contained false
  file bin/Release/net*/linux-x64/publish/FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll
  # Before fix: PE32+ executable (DLL) (GUI), x86-64  ← wrong
  # After fix:  ELF 64-bit LSB shared object, x86-64  ← correct
```
 
