### PR TITLE
TEST: increase lazy loading timeout for CI

### DIFF
--- a/Tests/FiftyOne.DeviceDetection.Cloud.Tests/FiftyOne.DeviceDetection.Cloud.Tests.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Cloud.Tests/FiftyOne.DeviceDetection.Cloud.Tests.csproj
@@ -13,7 +13,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="FiftyOne.Common.TestHelpers" Version="4.5.4" />
+		<PackageReference Include="FiftyOne.Common.TestHelpers" Version="5.1.3" />
 		<PackageReference Include="FiftyOne.Pipeline.Engines.TestHelpers" Version="4.5.30" />
 		<PackageReference Include="FiftyOne.Pipeline.Web" Version="4.5.30" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />

--- a/Tests/FiftyOne.DeviceDetection.TestHelpers/FiftyOne.DeviceDetection.TestHelpers.csproj
+++ b/Tests/FiftyOne.DeviceDetection.TestHelpers/FiftyOne.DeviceDetection.TestHelpers.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FiftyOne.Common.TestHelpers" Version="4.5.4" />
+    <PackageReference Include="FiftyOne.Common.TestHelpers" Version="5.1.3" />
   </ItemGroup>
 
 </Project>

--- a/Tests/FiftyOne.DeviceDetection.Tests.Core/DeviceDetectionTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.Tests.Core/DeviceDetectionTests.cs
@@ -162,7 +162,7 @@ namespace FiftyOne.DeviceDetection.Tests.Core
                 .SetDataFileSystemWatcher(false);
             if (useLazyLoading)
             {
-                builder.UseLazyLoading();
+                builder.UseLazyLoading(TimeSpan.FromSeconds(20));
             }
 
             CancellationTokenSource cancellationSource = new CancellationTokenSource();


### PR DESCRIPTION
otherwise we see test failures like: https://github.com/51Degrees/device-detection-dotnet/actions/runs/24325229216/job/71019189835