### PR TITLE
MetaDataTests: AssertInconclusive before .Average

### DIFF
--- a/Tests/FiftyOne.DeviceDetection.TestHelpers/Data/MetaDataTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.TestHelpers/Data/MetaDataTests.cs
@@ -174,6 +174,13 @@ namespace FiftyOne.DeviceDetection.TestHelpers.Data
                     hashes[i + 1].HashValue,
                     "Hashes were not equal");
             }
+            if (refreshResults.Count == 0)
+            {
+                Assert.Inconclusive(
+                    "No refreshes completed. At least 1 refresh needs to occur " +
+                    "while hash tasks are active in order for this test to be valid. " +
+                    "Check the ReloadDelay and HashTaskDelay settings.");
+            }
             var avgHashTime = hashes
                 .Average(h => (h.FinishTime - h.StartTime).TotalMilliseconds);
             var avgRefreshTime = refreshResults


### PR DESCRIPTION
in case we are on a slow CI and no refreshes completed on time - do not crash when calling .Average
see: https://github.com/51Degrees/device-detection-dotnet/actions/runs/24380347316/job/71202424334#step:5:626