### PR TITLE
FIX: Expose ProfileId in PropertyKeyed engine metadata

### DIFF
--- a/FiftyOne.DeviceDetection.PropertyKeyed/AssemblyInfo.cs
+++ b/FiftyOne.DeviceDetection.PropertyKeyed/AssemblyInfo.cs
@@ -1,0 +1,25 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("FiftyOne.DeviceDetection.PropertyKeyed.Tests")]

--- a/FiftyOne.DeviceDetection.PropertyKeyed/Data/DevicePropertyMetaData.cs
+++ b/FiftyOne.DeviceDetection.PropertyKeyed/Data/DevicePropertyMetaData.cs
@@ -31,9 +31,9 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Data
 {
     /// <summary>
     /// A wrapper around <see cref="IFiftyOneAspectPropertyMetaData"/>
-    /// that re-associates the property with the correct outer engine 
+    /// that re-associates the property with the correct outer engine
     /// rather than the internal DeviceDetectionHashEngine. Can also
-    /// create a synthetic property with explicit name, type, and 
+    /// create a synthetic property with explicit name, type, and
     /// item properties.
     /// </summary>
     public class DevicePropertyMetaData : IFiftyOneAspectPropertyMetaData
@@ -42,9 +42,8 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Data
 
         private readonly string _name;
         private readonly Type _type;
-        private readonly IReadOnlyList<IElementPropertyMetaData> 
+        private readonly IReadOnlyList<IElementPropertyMetaData>
             _itemProperties;
-        private readonly bool _isLeaf;
 
         /// <inheritdoc/>
         public IFlowElement Element { get; }
@@ -65,13 +64,7 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Data
 
         /// <inheritdoc/>
         public IReadOnlyList<IElementPropertyMetaData> ItemProperties =>
-            _inner != null
-                ? _inner.ItemProperties
-                : _isLeaf
-                    ? null
-                    : (_itemProperties ??
-                        (IReadOnlyList<IElementPropertyMetaData>)
-                        Array.Empty<IElementPropertyMetaData>());
+            _inner != null ? _inner.ItemProperties : _itemProperties;
 
         /// <inheritdoc/>
         public IReadOnlyDictionary<string, IElementPropertyMetaData> 
@@ -179,7 +172,7 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Data
         /// <summary>
         /// Creates a synthetic leaf property with the given name and
         /// type. <see cref="ItemProperties"/> returns null for leaves,
-        /// which lets callers tell them apart from container properties
+        /// so callers can tell them apart from container properties
         /// such as "Profiles".
         /// </summary>
         /// <param name="element">
@@ -201,7 +194,6 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Data
             _name = name;
             _itemProperties = null;
             _type = type;
-            _isLeaf = true;
         }
 
         // --- IFiftyOneAspectPropertyMetaData methods ---

--- a/FiftyOne.DeviceDetection.PropertyKeyed/Data/DevicePropertyMetaData.cs
+++ b/FiftyOne.DeviceDetection.PropertyKeyed/Data/DevicePropertyMetaData.cs
@@ -44,6 +44,7 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Data
         private readonly Type _type;
         private readonly IReadOnlyList<IElementPropertyMetaData> 
             _itemProperties;
+        private readonly bool _isLeaf;
 
         /// <inheritdoc/>
         public IFlowElement Element { get; }
@@ -66,9 +67,11 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Data
         public IReadOnlyList<IElementPropertyMetaData> ItemProperties =>
             _inner != null
                 ? _inner.ItemProperties
-                : (_itemProperties ?? 
-                    (IReadOnlyList<IElementPropertyMetaData>)
-                    Array.Empty<IElementPropertyMetaData>());
+                : _isLeaf
+                    ? null
+                    : (_itemProperties ??
+                        (IReadOnlyList<IElementPropertyMetaData>)
+                        Array.Empty<IElementPropertyMetaData>());
 
         /// <inheritdoc/>
         public IReadOnlyDictionary<string, IElementPropertyMetaData> 
@@ -171,6 +174,34 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Data
             _itemProperties = itemProperties
                 .Cast<IElementPropertyMetaData>().ToList();
             _type = type;
+        }
+
+        /// <summary>
+        /// Creates a synthetic leaf property with the given name and
+        /// type. <see cref="ItemProperties"/> returns null for leaves,
+        /// which lets callers tell them apart from container properties
+        /// such as "Profiles".
+        /// </summary>
+        /// <param name="element">
+        /// The engine to associate with this property.
+        /// </param>
+        /// <param name="name">
+        /// The property name (e.g. "ProfileId").
+        /// </param>
+        /// <param name="type">
+        /// The CLR type of this property.
+        /// </param>
+        public DevicePropertyMetaData(
+            IFlowElement element,
+            string name,
+            Type type)
+        {
+            Element = element;
+            _inner = null;
+            _name = name;
+            _itemProperties = null;
+            _type = type;
+            _isLeaf = true;
         }
 
         // --- IFiftyOneAspectPropertyMetaData methods ---

--- a/FiftyOne.DeviceDetection.PropertyKeyed/Services/DataSetService.cs
+++ b/FiftyOne.DeviceDetection.PropertyKeyed/Services/DataSetService.cs
@@ -175,14 +175,14 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Services
             }
         }
 
-        private static List<IFiftyOneAspectPropertyMetaData> BuildProperties(
+        internal static List<IFiftyOneAspectPropertyMetaData> BuildProperties(
             IReadOnlyList<IFiftyOneAspectPropertyMetaData> profileProperties,
             IFlowElement element)
         {
-            // Every profile has a ProfileId (IProfileMetaData.ProfileId),
-            // but the hash engine doesn't list it in Properties. Add it
-            // as a leaf so it shows up next to the rest of the profile
-            // fields in AccessibleProperties and the JSON output.
+            // Every profile has a ProfileId via IProfileMetaData.ProfileId,
+            // but the hash engine doesn't include it in Properties. Add
+            // it as a leaf so the engine's property surface lists it
+            // alongside the rest of the profile fields.
             var allProperties =
                 new List<IFiftyOneAspectPropertyMetaData>(
                     profileProperties.Count + 1)

--- a/FiftyOne.DeviceDetection.PropertyKeyed/Services/DataSetService.cs
+++ b/FiftyOne.DeviceDetection.PropertyKeyed/Services/DataSetService.cs
@@ -179,14 +179,31 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Services
             IReadOnlyList<IFiftyOneAspectPropertyMetaData> profileProperties,
             IFlowElement element)
         {
+            // Every profile has a ProfileId (IProfileMetaData.ProfileId),
+            // but the hash engine doesn't list it in Properties. Add it
+            // as a leaf so it shows up next to the rest of the profile
+            // fields in AccessibleProperties and the JSON output.
+            var allProperties =
+                new List<IFiftyOneAspectPropertyMetaData>(
+                    profileProperties.Count + 1)
+                {
+                    new DevicePropertyMetaData(
+                        element,
+                        PROFILE_ID_PROPERTY_NAME,
+                        typeof(string)),
+                };
+            allProperties.AddRange(profileProperties);
+
             return new List<IFiftyOneAspectPropertyMetaData>
             {
                 new DevicePropertyMetaData(
                     element,
                     PropertyKeyedDataSet.PROPERTY_PREFIX_NAME,
-                    profileProperties,
+                    allProperties.AsReadOnly(),
                     typeof(IReadOnlyList<IDeviceData>))
             };
         }
+
+        internal const string PROFILE_ID_PROPERTY_NAME = "ProfileId";
     }
 }

--- a/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/DataSetServiceTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/DataSetServiceTests.cs
@@ -1,0 +1,122 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.DeviceDetection.PropertyKeyed.Services;
+using FiftyOne.Pipeline.Core.FlowElements;
+using FiftyOne.Pipeline.Engines.FiftyOne.Data;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Linq;
+
+namespace FiftyOne.DeviceDetection.PropertyKeyed.Tests
+{
+    /// <summary>
+    /// Exercises <see cref="DataSetService.BuildProperties"/>, which
+    /// wraps the engine's profile properties under the "Profiles"
+    /// container and prepends a synthetic ProfileId leaf.
+    /// </summary>
+    [TestClass]
+    public class DataSetServiceTests
+    {
+        private static Mock<IFiftyOneAspectPropertyMetaData> ProfileProp(
+            string name)
+        {
+            var mock = new Mock<IFiftyOneAspectPropertyMetaData>();
+            mock.SetupGet(p => p.Name).Returns(name);
+            return mock;
+        }
+
+        [TestMethod]
+        public void BuildProperties_WrapsEverythingInProfilesContainer()
+        {
+            var element = Mock.Of<IFlowElement>();
+
+            var result = DataSetService.BuildProperties(
+                Array.Empty<IFiftyOneAspectPropertyMetaData>(),
+                element);
+
+            Assert.HasCount(1, result);
+            Assert.AreEqual("Profiles", result[0].Name);
+        }
+
+        [TestMethod]
+        public void BuildProperties_PrependsProfileIdBeforeProfileProperties()
+        {
+            var element = Mock.Of<IFlowElement>();
+            var cpu = ProfileProp("CPU").Object;
+            var isMobile = ProfileProp("IsMobile").Object;
+
+            var result = DataSetService.BuildProperties(
+                new[] { cpu, isMobile }, element);
+
+            var items = result[0].ItemProperties.ToList();
+            Assert.HasCount(3, items);
+            Assert.AreEqual("ProfileId", items[0].Name);
+            Assert.AreEqual("CPU", items[1].Name);
+            Assert.AreEqual("IsMobile", items[2].Name);
+        }
+
+        [TestMethod]
+        public void BuildProperties_ProfileIdIsALeaf()
+        {
+            var element = Mock.Of<IFlowElement>();
+
+            var result = DataSetService.BuildProperties(
+                Array.Empty<IFiftyOneAspectPropertyMetaData>(),
+                element);
+
+            var profileId = result[0].ItemProperties[0];
+            Assert.IsNull(
+                profileId.ItemProperties,
+                "ProfileId should be a leaf (ItemProperties = null) " +
+                "so callers can tell it apart from container properties.");
+        }
+
+        [TestMethod]
+        public void BuildProperties_ProfileIdIsTypedAsString()
+        {
+            var element = Mock.Of<IFlowElement>();
+
+            var result = DataSetService.BuildProperties(
+                Array.Empty<IFiftyOneAspectPropertyMetaData>(),
+                element);
+
+            var profileId = result[0].ItemProperties[0];
+            Assert.AreEqual(typeof(string), profileId.Type);
+        }
+
+        [TestMethod]
+        public void BuildProperties_EmptyInputStillProducesProfileId()
+        {
+            var element = Mock.Of<IFlowElement>();
+
+            var result = DataSetService.BuildProperties(
+                Array.Empty<IFiftyOneAspectPropertyMetaData>(),
+                element);
+
+            var items = result[0].ItemProperties;
+            Assert.HasCount(1, items);
+            Assert.AreEqual("ProfileId", items[0].Name);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

PropertyKeyed engines (TacEngine, NativeEngine) didn't include ProfileId in their property metadata, even though every profile has one via IProfileMetaData.ProfileId on the native hash engine. The legacy CloudTACKeyedEngine did include it because it read its property list  straight from the .trie.zip CSV header, where ProfileId was the first column.

### Changes:

- DataSetService.BuildProperties puts a ProfileId leaf before the other profile properties.
- DevicePropertyMetaData gets a constructor for leaf properties. ItemProperties returns null for leaves, so the null check in PropertyKeyedPropertiesService still tells leaves from containers.