### PR TITLE
FEAT: Add ITdlSourceResolver service with GitHub-backed default to RobotsTxtEngine

### DIFF
--- a/FiftyOne.DeviceDetection.RobotsTxt/FiftyOne.DeviceDetection.RobotsTxt.csproj
+++ b/FiftyOne.DeviceDetection.RobotsTxt/FiftyOne.DeviceDetection.RobotsTxt.csproj
@@ -34,10 +34,12 @@
 
   <ItemGroup>
     <None Remove="license-robots.txt" />
+    <None Remove="tdlSources.json" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="license-robots.txt" />
+    <EmbeddedResource Include="tdlSources.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FiftyOne.DeviceDetection.RobotsTxt/FlowElements/RobotsTxtBuilder.cs
+++ b/FiftyOne.DeviceDetection.RobotsTxt/FlowElements/RobotsTxtBuilder.cs
@@ -21,6 +21,7 @@
  * ********************************************************************* */
 
 using FiftyOne.DeviceDetection.RobotsTxt.Data;
+using FiftyOne.DeviceDetection.RobotsTxt.Services;
 using FiftyOne.Pipeline.Engines;
 using FiftyOne.Pipeline.Engines.FiftyOne.FlowElements;
 using Microsoft.Extensions.Logging;
@@ -36,6 +37,8 @@ namespace FiftyOne.DeviceDetection.RobotsTxt.FlowElements
         RobotsTxtEngineBuilder,
         RobotsTxtEngine>
     {
+        private ITdlSourceResolver _tdlResolver;
+
         public RobotsTxtEngineBuilder(ILoggerFactory loggerFactory)
             : base(loggerFactory)
         { }
@@ -46,11 +49,28 @@ namespace FiftyOne.DeviceDetection.RobotsTxt.FlowElements
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Optional. Plugs in a resolver that maps short TDL ids in
+        /// the <c>query.robotstxt.tdl</c> evidence to URLs. If not
+        /// set, only values that are already absolute URIs reach the
+        /// generated robots.txt; everything else is dropped per the
+        /// IETF-Robots TDL specification.
+        /// </summary>
+        public RobotsTxtEngineBuilder SetTdlSourceResolver(
+            ITdlSourceResolver resolver)
+        {
+            _tdlResolver = resolver;
+            return this;
+        }
+
         /// <inheritdoc/>
         protected override RobotsTxtEngine CreateEngine(
             List<string> properties)
         {
-            return new RobotsTxtEngine(properties, _loggerFactory);
+            return new RobotsTxtEngine(
+                properties,
+                _loggerFactory,
+                _tdlResolver);
         }
     }
 }

--- a/FiftyOne.DeviceDetection.RobotsTxt/FlowElements/RobotsTxtBuilder.cs
+++ b/FiftyOne.DeviceDetection.RobotsTxt/FlowElements/RobotsTxtBuilder.cs
@@ -31,17 +31,29 @@ using System.Collections.Generic;
 namespace FiftyOne.DeviceDetection.RobotsTxt.FlowElements
 {
     /// <summary>
-    /// Builder for <see cref="RobotsTxtEngine"/>.
+    /// Builder for <see cref="RobotsTxtEngine"/>. The constructor
+    /// attaches a <see cref="GitHubTdlSourceResolver"/> by default so
+    /// short TDL ids in <c>query.robotstxt.tdl</c> evidence are
+    /// resolved against the embedded sources out of the box. Pass a
+    /// different resolver via <see cref="SetTdlSourceResolver"/>, or
+    /// <c>null</c> to disable id resolution entirely (e.g. air-gapped
+    /// deployments).
     /// </summary>
     public class RobotsTxtEngineBuilder : PropertyKeyedEngineBuilderBase<
         RobotsTxtEngineBuilder,
         RobotsTxtEngine>
     {
+        private const string DefaultUserAgent =
+            "FiftyOne.DeviceDetection.RobotsTxt";
+
         private ITdlSourceResolver _tdlResolver;
 
         public RobotsTxtEngineBuilder(ILoggerFactory loggerFactory)
             : base(loggerFactory)
-        { }
+        {
+            _tdlResolver = GitHubTdlSourceResolver.CreateDefault(
+                DefaultUserAgent, loggerFactory);
+        }
 
         public RobotsTxtEngineBuilder SetPerformanceProfile(
             PerformanceProfiles profile)
@@ -50,17 +62,51 @@ namespace FiftyOne.DeviceDetection.RobotsTxt.FlowElements
         }
 
         /// <summary>
-        /// Optional. Plugs in a resolver that maps short TDL ids in
-        /// the <c>query.robotstxt.tdl</c> evidence to URLs. If not
-        /// set, only values that are already absolute URIs reach the
-        /// generated robots.txt; everything else is dropped per the
-        /// IETF-Robots TDL specification.
+        /// Replaces the resolver attached by the constructor. Pass
+        /// your own <see cref="ITdlSourceResolver"/> implementation
+        /// to use a different source list, a static map, or a
+        /// non-GitHub backend; pass <c>null</c> to disable id
+        /// resolution and accept only absolute URIs as before.
         /// </summary>
         public RobotsTxtEngineBuilder SetTdlSourceResolver(
             ITdlSourceResolver resolver)
         {
             _tdlResolver = resolver;
             return this;
+        }
+
+        /// <summary>
+        /// Replaces the constructor's default resolver with another
+        /// <see cref="GitHubTdlSourceResolver"/> that uses the given
+        /// User-Agent. Use this when you want the same default
+        /// behaviour but with an identifying UA (recommended) instead
+        /// of the engine's generic one.
+        /// </summary>
+        /// <param name="userAgent">
+        /// Identifying string for the HTTP User-Agent header. GitHub
+        /// rejects requests without one.
+        /// </param>
+        public RobotsTxtEngineBuilder UseDefaultTdlSourceResolver(
+            string userAgent)
+        {
+            return SetTdlSourceResolver(
+                GitHubTdlSourceResolver.CreateDefault(
+                    userAgent, _loggerFactory));
+        }
+
+        /// <summary>
+        /// Sets the User-Agent used by the default GitHub-backed
+        /// resolver. Equivalent to
+        /// <see cref="UseDefaultTdlSourceResolver"/> — exposed under
+        /// this name so pipeline configuration can drive it from
+        /// <c>"BuildParameters": { "UserAgent": "..." }</c> in
+        /// appsettings.json. Has no effect if you have already
+        /// installed a non-GitHub resolver via
+        /// <see cref="SetTdlSourceResolver"/>.
+        /// </summary>
+        public RobotsTxtEngineBuilder SetUserAgent(string userAgent)
+        {
+            return UseDefaultTdlSourceResolver(userAgent);
         }
 
         /// <inheritdoc/>

--- a/FiftyOne.DeviceDetection.RobotsTxt/FlowElements/RobotsTxtEngine.cs
+++ b/FiftyOne.DeviceDetection.RobotsTxt/FlowElements/RobotsTxtEngine.cs
@@ -102,6 +102,8 @@ namespace FiftyOne.DeviceDetection.RobotsTxt.FlowElements
 
         private readonly ILogger<RobotsTxtData> _loggerData;
 
+        private readonly ITdlSourceResolver _tdlResolver;
+
         public override string DataSourceTier => _dataSourceTier;
         private string _dataSourceTier;
 
@@ -121,9 +123,10 @@ namespace FiftyOne.DeviceDetection.RobotsTxt.FlowElements
         private IList<IAspectPropertyMetaData> _requiredProperties;
 
         public RobotsTxtEngine(
-            List<string> properties, 
-            ILoggerFactory loggerFactory) : base(
-                loggerFactory.CreateLogger<RobotsTxtEngine>(), 
+            List<string> properties,
+            ILoggerFactory loggerFactory,
+            ITdlSourceResolver tdlResolver = null) : base(
+                loggerFactory.CreateLogger<RobotsTxtEngine>(),
                 CreateAspectData)
         {
             _properties = properties;
@@ -132,6 +135,7 @@ namespace FiftyOne.DeviceDetection.RobotsTxt.FlowElements
             _queryService = new PropertyValueQueryService(
                 ["CrawlerUsage"],
                 loggerFactory);
+            _tdlResolver = tdlResolver;
         }
 
         private static IRobotsTxtData CreateAspectData(
@@ -289,10 +293,13 @@ namespace FiftyOne.DeviceDetection.RobotsTxt.FlowElements
 
         /// <summary>
         /// Parses TDL URIs from evidence. Accepts a single value or a list
-        /// of values joined with ',' or '|'. Non-URI values are silently
-        /// dropped per the IETF-Robots TDL specification.
+        /// of values joined with ',' or '|'. Each entry is treated as an
+        /// absolute URI first; if that fails and an
+        /// <see cref="ITdlSourceResolver"/> is registered, it gets a chance
+        /// to resolve known short ids to URLs. Anything that ends up
+        /// non-URI is silently dropped per the IETF-Robots TDL specification.
         /// </summary>
-        private static IReadOnlyList<Uri> GetTdls(IFlowData data)
+        private IReadOnlyList<Uri> GetTdls(IFlowData data)
         {
             if (data.TryGetEvidence<string>(
                     Constants.TdlEvidenceKey,
@@ -306,11 +313,22 @@ namespace FiftyOne.DeviceDetection.RobotsTxt.FlowElements
                     TdlSeparators,
                     StringSplitOptions.RemoveEmptyEntries
                         | StringSplitOptions.TrimEntries)
-                .Select(s => Uri.TryCreate(s, UriKind.Absolute, out var u)
-                    ? u
-                    : null)
+                .Select(ResolveTdlEntry)
                 .Where(u => u != null)
                 .ToArray();
+        }
+
+        private Uri ResolveTdlEntry(string entry)
+        {
+            if (Uri.TryCreate(entry, UriKind.Absolute, out var u))
+            {
+                return u;
+            }
+            if (_tdlResolver?.IsKnown(entry) == true)
+            {
+                return _tdlResolver.Resolve(entry);
+            }
+            return null;
         }
 
         private IEnumerable<KeyValuePair<string, object>>

--- a/FiftyOne.DeviceDetection.RobotsTxt/Model/TdlSource.cs
+++ b/FiftyOne.DeviceDetection.RobotsTxt/Model/TdlSource.cs
@@ -1,0 +1,70 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+namespace FiftyOne.DeviceDetection.RobotsTxt.Model;
+
+/// <summary>
+/// Mapping entry that tells a resolver where to look on GitHub for the
+/// versioned TDL files that belong to a short id, and how to format the
+/// public URL once the latest file has been picked.
+/// </summary>
+public class TdlSource
+{
+    /// <summary>
+    /// Name of the regex group in <see cref="FilePattern"/> that
+    /// captures the version number used to pick the latest file.
+    /// </summary>
+    public const string VersionGroupName = "n";
+
+    /// <summary>
+    /// Placeholder in <see cref="UrlTemplate"/> swapped out for the
+    /// winning file name.
+    /// </summary>
+    public const string NamePlaceholder = "{name}";
+
+    /// <summary>
+    /// Identifier callers send instead of a full URL (e.g. "MOW-SOCW").
+    /// </summary>
+    public string Id { get; set; }
+
+    /// <summary>
+    /// GitHub repository in "owner/name" form.
+    /// </summary>
+    public string Repository { get; set; }
+
+    /// <summary>
+    /// Path inside the repository where the versioned files sit.
+    /// </summary>
+    public string Directory { get; set; }
+
+    /// <summary>
+    /// Regex over file names with a named group "n" capturing the
+    /// version number. The highest n wins.
+    /// </summary>
+    public string FilePattern { get; set; }
+
+    /// <summary>
+    /// Public URL template; "{name}" is replaced by the winning
+    /// file name.
+    /// </summary>
+    public string UrlTemplate { get; set; }
+}

--- a/FiftyOne.DeviceDetection.RobotsTxt/Services/GitHubTdlSourceResolver.cs
+++ b/FiftyOne.DeviceDetection.RobotsTxt/Services/GitHubTdlSourceResolver.cs
@@ -49,6 +49,51 @@ public sealed class GitHubTdlSourceResolver : ITdlSourceResolver, IDisposable
     /// </summary>
     public static readonly TimeSpan DefaultCacheTtl = TimeSpan.FromHours(12);
 
+    /// <summary>
+    /// Builds a resolver wired up to api.github.com with the engine's
+    /// embedded default sources (see <see cref="TdlSourcesLoader.LoadDefault"/>).
+    /// Use this when you want short-id resolution out of the box and
+    /// don't need a custom HttpClient or source list. If you do, build
+    /// the resolver via the public constructor instead.
+    /// </summary>
+    /// <param name="userAgent">
+    /// Identifying string for the HTTP User-Agent header. GitHub
+    /// rejects requests without a User-Agent, and asks that the
+    /// value be descriptive enough to identify the caller.
+    /// </param>
+    /// <param name="loggerFactory">
+    /// Logger factory used to build the resolver's logger.
+    /// </param>
+    /// <exception cref="ArgumentException"><paramref name="userAgent"/> is empty.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="loggerFactory"/> is null.</exception>
+    public static GitHubTdlSourceResolver CreateDefault(
+        string userAgent, ILoggerFactory loggerFactory)
+    {
+        if (string.IsNullOrWhiteSpace(userAgent))
+        {
+            throw new ArgumentException(
+                "User-Agent must be supplied.", nameof(userAgent));
+        }
+        if (loggerFactory == null)
+        {
+            throw new ArgumentNullException(nameof(loggerFactory));
+        }
+
+        var http = new HttpClient
+        {
+            BaseAddress = new Uri("https://api.github.com/"),
+            Timeout = TimeSpan.FromSeconds(10),
+        };
+        http.DefaultRequestHeaders.UserAgent.ParseAdd(userAgent);
+        http.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+        http.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
+
+        return new GitHubTdlSourceResolver(
+            http,
+            TdlSourcesLoader.LoadDefault(),
+            loggerFactory.CreateLogger<GitHubTdlSourceResolver>());
+    }
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNameCaseInsensitive = true,

--- a/FiftyOne.DeviceDetection.RobotsTxt/Services/GitHubTdlSourceResolver.cs
+++ b/FiftyOne.DeviceDetection.RobotsTxt/Services/GitHubTdlSourceResolver.cs
@@ -1,0 +1,234 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.DeviceDetection.RobotsTxt.Model;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace FiftyOne.DeviceDetection.RobotsTxt.Services;
+
+/// <summary>
+/// Resolves TDL ids by listing the configured GitHub directory and
+/// picking the file with the highest version number. Results live
+/// in an in-memory cache; if a refresh fails we keep returning the
+/// previous URL.
+/// </summary>
+public sealed class GitHubTdlSourceResolver : ITdlSourceResolver, IDisposable
+{
+    /// <summary>
+    /// Default time a cache entry stays fresh before we try to
+    /// refresh it. 12 hours covers a 1-2/day publication cadence
+    /// while staying well under the 60/hour unauthenticated GitHub
+    /// API limit.
+    /// </summary>
+    public static readonly TimeSpan DefaultCacheTtl = TimeSpan.FromHours(12);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly HttpClient _http;
+    private readonly IReadOnlyDictionary<string, TdlSource> _sources;
+    private readonly ILogger<GitHubTdlSourceResolver> _logger;
+    private readonly TimeProvider _clock;
+    private readonly TimeSpan _ttl;
+
+    private readonly ConcurrentDictionary<string, CacheEntry> _cache =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _semaphores =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Creates the resolver.
+    /// </summary>
+    /// <param name="http">
+    /// HttpClient configured with a BaseAddress pointing at the
+    /// GitHub API and a User-Agent header (GitHub rejects requests
+    /// that lack one).
+    /// </param>
+    /// <param name="sources">
+    /// Map of id → source descriptor. Loaders are typically
+    /// host-specific (JSON, env, etc.) and live outside the engine.
+    /// </param>
+    /// <param name="logger">Logger.</param>
+    /// <param name="clock">Time source; defaults to <see cref="TimeProvider.System"/>.</param>
+    /// <param name="ttl">Cache TTL; defaults to <see cref="DefaultCacheTtl"/>.</param>
+    public GitHubTdlSourceResolver(
+        HttpClient http,
+        IReadOnlyDictionary<string, TdlSource> sources,
+        ILogger<GitHubTdlSourceResolver> logger,
+        TimeProvider clock = null,
+        TimeSpan? ttl = null)
+    {
+        _http = http ?? throw new ArgumentNullException(nameof(http));
+        _sources = sources ?? throw new ArgumentNullException(nameof(sources));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _clock = clock ?? TimeProvider.System;
+        _ttl = ttl ?? DefaultCacheTtl;
+    }
+
+    /// <inheritdoc/>
+    public bool IsKnown(string id) =>
+        !string.IsNullOrEmpty(id) && _sources.ContainsKey(id);
+
+    /// <inheritdoc/>
+    public Uri Resolve(string id)
+    {
+        if (string.IsNullOrEmpty(id)
+            || !_sources.TryGetValue(id, out var source))
+        {
+            return null;
+        }
+
+        var now = _clock.GetUtcNow();
+        if (_cache.TryGetValue(id, out var cached) && cached.FreshUntil > now)
+        {
+            return cached.Url;
+        }
+
+        // Single-flight: only one refresh per id at a time. Other
+        // callers wait on the semaphore and pick up the cached value
+        // populated by the first one.
+        var sem = _semaphores.GetOrAdd(id, _ => new SemaphoreSlim(1, 1));
+        sem.Wait();
+        try
+        {
+            now = _clock.GetUtcNow();
+            if (_cache.TryGetValue(id, out cached) && cached.FreshUntil > now)
+            {
+                return cached.Url;
+            }
+
+            try
+            {
+                var fresh = FetchLatest(source);
+                if (fresh != null)
+                {
+                    _cache[id] = new CacheEntry(fresh, now + _ttl);
+                    return fresh;
+                }
+                _logger.LogWarning(
+                    "TDL source '{Id}' has no files matching its pattern.",
+                    id);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "TDL source '{Id}' refresh failed; falling back to " +
+                    "cached value if any.", id);
+            }
+
+            return cached?.Url;
+        }
+        finally
+        {
+            sem.Release();
+        }
+    }
+
+    private Uri FetchLatest(TdlSource source)
+    {
+        var path = $"repos/{source.Repository}/contents/{source.Directory}";
+        using var req = new HttpRequestMessage(HttpMethod.Get, path);
+        using var resp = _http.Send(req);
+        if (!resp.IsSuccessStatusCode)
+        {
+            _logger.LogWarning(
+                "GitHub returned {Status} listing '{Repo}/{Dir}'.",
+                (int)resp.StatusCode, source.Repository, source.Directory);
+            return null;
+        }
+
+        List<GitHubContent> entries;
+        using (var stream = resp.Content.ReadAsStream())
+        {
+            entries = JsonSerializer.Deserialize<List<GitHubContent>>(
+                stream, JsonOptions);
+        }
+        if (entries == null)
+        {
+            return null;
+        }
+
+        var regex = new Regex(source.FilePattern);
+        string winnerName = null;
+        long winnerN = -1;
+        foreach (var entry in entries)
+        {
+            if (entry == null) continue;
+            if (!"file".Equals(entry.Type, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            if (string.IsNullOrEmpty(entry.Name)) continue;
+
+            var match = regex.Match(entry.Name);
+            if (!match.Success) continue;
+            var nGroup = match.Groups[TdlSource.VersionGroupName];
+            if (!nGroup.Success) continue;
+            if (!long.TryParse(nGroup.Value, out var n)) continue;
+
+            if (n > winnerN)
+            {
+                winnerN = n;
+                winnerName = entry.Name;
+            }
+        }
+
+        if (winnerName == null)
+        {
+            return null;
+        }
+
+        var url = source.UrlTemplate.Replace(
+            TdlSource.NamePlaceholder, winnerName);
+        return Uri.TryCreate(url, UriKind.Absolute, out var u) ? u : null;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        foreach (var sem in _semaphores.Values)
+        {
+            sem.Dispose();
+        }
+    }
+
+    private sealed record CacheEntry(Uri Url, DateTimeOffset FreshUntil);
+
+    private sealed class GitHubContent
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+    }
+}

--- a/FiftyOne.DeviceDetection.RobotsTxt/Services/ITdlSourceResolver.cs
+++ b/FiftyOne.DeviceDetection.RobotsTxt/Services/ITdlSourceResolver.cs
@@ -1,0 +1,48 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using System;
+
+namespace FiftyOne.DeviceDetection.RobotsTxt.Services;
+
+/// <summary>
+/// Plug-in for <see cref="FlowElements.RobotsTxtEngine"/> that maps a
+/// short TDL identifier (e.g. "MOW-SOCW") to the current best URL for
+/// that source. The engine calls into this for any TDL evidence value
+/// that is not already an absolute URI; consumers that don't register
+/// a resolver get the default "URI-only" behaviour.
+/// </summary>
+public interface ITdlSourceResolver
+{
+    /// <summary>
+    /// Returns true if <paramref name="id"/> is a configured source.
+    /// Comparison is case-insensitive.
+    /// </summary>
+    bool IsKnown(string id);
+
+    /// <summary>
+    /// Resolves a known <paramref name="id"/> to the latest available
+    /// URL. Returns null if the id is unknown, or if the live lookup
+    /// failed and there is no cached value to fall back on.
+    /// </summary>
+    Uri Resolve(string id);
+}

--- a/FiftyOne.DeviceDetection.RobotsTxt/Services/TdlSourcesLoader.cs
+++ b/FiftyOne.DeviceDetection.RobotsTxt/Services/TdlSourcesLoader.cs
@@ -1,0 +1,203 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.DeviceDetection.RobotsTxt.Model;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace FiftyOne.DeviceDetection.RobotsTxt.Services;
+
+/// <summary>
+/// Reads tdlSources.json into a lookup keyed by source id. Three
+/// entry points: <see cref="LoadDefault"/> for the file embedded in
+/// the engine assembly, <see cref="LoadFromFile"/> for a host-supplied
+/// file path, and <see cref="LoadFromJson"/> for an in-memory string.
+/// Validation happens up front so any config mistake fails fast
+/// rather than slipping into runtime.
+/// </summary>
+public static class TdlSourcesLoader
+{
+    private const string DefaultResourceSuffix = "tdlSources.json";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>
+    /// Loads the default sources shipped with the engine
+    /// (embedded JSON resource). Lookups against the returned
+    /// dictionary are case-insensitive.
+    /// </summary>
+    public static IReadOnlyDictionary<string, TdlSource> LoadDefault()
+    {
+        var asm = typeof(TdlSourcesLoader).Assembly;
+        var resourceName = asm.GetManifestResourceNames()
+            .FirstOrDefault(n => n.EndsWith(
+                DefaultResourceSuffix, StringComparison.Ordinal))
+            ?? throw new InvalidOperationException(
+                $"Embedded resource '{DefaultResourceSuffix}' not " +
+                $"found in {asm.FullName}.");
+
+        using var stream = asm.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException(
+                $"Failed to open embedded resource '{resourceName}'.");
+        using var reader = new StreamReader(stream);
+        return Parse(reader.ReadToEnd(), $"embedded:{resourceName}");
+    }
+
+    /// <summary>
+    /// Loads sources from a JSON file at the given path. Use this to
+    /// replace the default list with your own.
+    /// </summary>
+    /// <exception cref="ArgumentException"><paramref name="filePath"/> is empty.</exception>
+    /// <exception cref="FileNotFoundException">File does not exist.</exception>
+    /// <exception cref="InvalidOperationException">JSON is malformed or any entry is invalid.</exception>
+    public static IReadOnlyDictionary<string, TdlSource> LoadFromFile(
+        string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            throw new ArgumentException(
+                "File path must be supplied.", nameof(filePath));
+        }
+        if (!File.Exists(filePath))
+        {
+            throw new FileNotFoundException(
+                $"TDL sources file not found at '{filePath}'.", filePath);
+        }
+        return Parse(File.ReadAllText(filePath), filePath);
+    }
+
+    /// <summary>
+    /// Loads sources from an in-memory JSON string. Handy for tests
+    /// and for fully in-process configuration where no file system
+    /// is involved.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="json"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">JSON is malformed or any entry is invalid.</exception>
+    public static IReadOnlyDictionary<string, TdlSource> LoadFromJson(
+        string json)
+    {
+        if (json == null)
+        {
+            throw new ArgumentNullException(nameof(json));
+        }
+        return Parse(json, "<inline>");
+    }
+
+    private static IReadOnlyDictionary<string, TdlSource> Parse(
+        string json, string source)
+    {
+        List<TdlSource> entries;
+        try
+        {
+            entries = JsonSerializer.Deserialize<List<TdlSource>>(
+                json, JsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException(
+                $"TDL sources at '{source}' is not valid JSON.", ex);
+        }
+
+        if (entries == null)
+        {
+            throw new InvalidOperationException(
+                $"TDL sources at '{source}' must contain a JSON array.");
+        }
+
+        var result = new Dictionary<string, TdlSource>(
+            StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < entries.Count; i++)
+        {
+            var entry = entries[i];
+            Validate(entry, i, source);
+            if (result.ContainsKey(entry.Id))
+            {
+                throw new InvalidOperationException(
+                    $"Duplicate TDL source id '{entry.Id}' in '{source}'.");
+            }
+            result.Add(entry.Id, entry);
+        }
+        return result;
+    }
+
+    private static void Validate(
+        TdlSource entry, int index, string source)
+    {
+        if (entry == null)
+        {
+            throw new InvalidOperationException(
+                $"TDL source at index {index} in '{source}' is null.");
+        }
+
+        RequireNonEmpty(entry.Id, nameof(entry.Id), index, source);
+        RequireNonEmpty(entry.Repository, nameof(entry.Repository), index, source);
+        RequireNonEmpty(entry.Directory, nameof(entry.Directory), index, source);
+        RequireNonEmpty(entry.FilePattern, nameof(entry.FilePattern), index, source);
+        RequireNonEmpty(entry.UrlTemplate, nameof(entry.UrlTemplate), index, source);
+
+        Regex regex;
+        try
+        {
+            regex = new Regex(entry.FilePattern);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new InvalidOperationException(
+                $"TDL source '{entry.Id}' in '{source}' has an " +
+                $"invalid FilePattern.", ex);
+        }
+
+        if (!regex.GetGroupNames().Contains(TdlSource.VersionGroupName))
+        {
+            throw new InvalidOperationException(
+                $"TDL source '{entry.Id}' in '{source}' FilePattern " +
+                $"must declare a named group " +
+                $"'(?<{TdlSource.VersionGroupName}>...)'.");
+        }
+
+        if (!entry.UrlTemplate.Contains(TdlSource.NamePlaceholder))
+        {
+            throw new InvalidOperationException(
+                $"TDL source '{entry.Id}' in '{source}' UrlTemplate " +
+                $"must include the '{TdlSource.NamePlaceholder}' " +
+                $"placeholder.");
+        }
+    }
+
+    private static void RequireNonEmpty(
+        string value, string field, int index, string source)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException(
+                $"TDL source at index {index} in '{source}' is " +
+                $"missing '{field}'.");
+        }
+    }
+}

--- a/FiftyOne.DeviceDetection.RobotsTxt/tdlSources.json
+++ b/FiftyOne.DeviceDetection.RobotsTxt/tdlSources.json
@@ -1,0 +1,9 @@
+[
+  {
+    "Id": "MOW-SOCW",
+    "Repository": "movementforanopenweb/terms-documents",
+    "Directory": "socw",
+    "FilePattern": "^(?<n>\\d+)\\.txt$",
+    "UrlTemplate": "https://m4ow.uk/socw/{name}"
+  }
+]

--- a/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/RobotsTxtBuilderTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/RobotsTxtBuilderTests.cs
@@ -21,7 +21,9 @@
  * ********************************************************************* */
 
 using FiftyOne.DeviceDetection.RobotsTxt.FlowElements;
+using FiftyOne.DeviceDetection.RobotsTxt.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Reflection;
 using static FiftyOne.DeviceDetection.TestHelpers.Utils;
@@ -57,5 +59,79 @@ namespace FiftyOne.DeviceDetection.RobotsTxt.Tests
         {
             AssertSingleParameterlessBuild(typeof(RobotsTxtEngineBuilder));
         }
+
+        /// <summary>
+        /// Out of the box the builder ships with a GitHub-backed
+        /// resolver attached, so a consumer that lists
+        /// "RobotsTxtEngineBuilder" in pipeline config gets short-id
+        /// resolution without any extra wiring.
+        /// </summary>
+        [TestMethod]
+        public void Constructor_AttachesDefaultResolverThatKnowsMowSocw()
+        {
+            var builder = new RobotsTxtEngineBuilder(
+                NullLoggerFactory.Instance);
+
+            var field = typeof(RobotsTxtEngineBuilder).GetField(
+                "_tdlResolver",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(field);
+            var resolver = field.GetValue(builder) as ITdlSourceResolver;
+            Assert.IsNotNull(resolver,
+                "constructor should attach a default resolver");
+            Assert.IsTrue(resolver.IsKnown("MOW-SOCW"));
+        }
+
+        /// <summary>
+        /// Passing null to SetTdlSourceResolver disables short-id
+        /// resolution — the documented opt-out for air-gapped
+        /// deployments that cannot reach GitHub.
+        /// </summary>
+        [TestMethod]
+        public void SetTdlSourceResolver_Null_DisablesResolver()
+        {
+            var builder = new RobotsTxtEngineBuilder(
+                    NullLoggerFactory.Instance)
+                .SetTdlSourceResolver(null);
+
+            var field = typeof(RobotsTxtEngineBuilder).GetField(
+                "_tdlResolver",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNull(field.GetValue(builder));
+        }
+
+        /// <summary>
+        /// SetUserAgent is the BuildParameters-friendly entry point
+        /// for the same logic; pipeline configuration drives it via
+        /// "BuildParameters": { "UserAgent": "..." } in appsettings.json.
+        /// </summary>
+        [TestMethod]
+        public void SetUserAgent_AttachesResolverWithGivenUserAgent()
+        {
+            var builder = new RobotsTxtEngineBuilder(NullLoggerFactory.Instance)
+                .SetUserAgent("TestApp/1.0");
+
+            var field = typeof(RobotsTxtEngineBuilder).GetField(
+                "_tdlResolver",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var resolver = field.GetValue(builder) as ITdlSourceResolver;
+            Assert.IsNotNull(resolver);
+            Assert.IsTrue(resolver.IsKnown("MOW-SOCW"));
+        }
+
+        /// <summary>
+        /// UseDefaultTdlSourceResolver is fluent — it returns the same
+        /// builder instance so callers can chain further configuration.
+        /// </summary>
+        [TestMethod]
+        public void UseDefaultTdlSourceResolver_ReturnsSameBuilderForChaining()
+        {
+            var builder = new RobotsTxtEngineBuilder(NullLoggerFactory.Instance);
+
+            var returned = builder.UseDefaultTdlSourceResolver("TestApp/1.0");
+
+            Assert.AreSame(builder, returned);
+        }
+
     }
 }

--- a/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/Services/GitHubTdlSourceResolverLiveTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/Services/GitHubTdlSourceResolverLiveTests.cs
@@ -1,0 +1,90 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.DeviceDetection.RobotsTxt.Model;
+using FiftyOne.DeviceDetection.RobotsTxt.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+
+namespace FiftyOne.DeviceDetection.RobotsTxt.Tests.Services
+{
+    /// <summary>
+    /// Live network smoke test that calls the real GitHub API.
+    /// Tagged so CI can skip it via <c>--filter TestCategory!=LiveNetwork</c>.
+    /// </summary>
+    [TestClass]
+    public class GitHubTdlSourceResolverLiveTests
+    {
+        /// <summary>
+        /// Hits the real api.github.com and checks the resolved URL
+        /// matches the friendly m4ow.uk pattern. Burns one request
+        /// from the unauthenticated 60/hour pool.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("LiveNetwork")]
+        public void Resolve_AgainstRealGitHub_ReturnsMowSocwUrl()
+        {
+            using var http = new HttpClient
+            {
+                BaseAddress = new Uri("https://api.github.com/"),
+                Timeout = TimeSpan.FromSeconds(10),
+            };
+            http.DefaultRequestHeaders.UserAgent.ParseAdd("51Degrees-CloudService");
+            http.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+            http.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
+
+            var sources = new Dictionary<string, TdlSource>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                ["MOW-SOCW"] = new TdlSource
+                {
+                    Id = "MOW-SOCW",
+                    Repository = "movementforanopenweb/terms-documents",
+                    Directory = "socw",
+                    FilePattern = @"^(?<n>\d+)\.txt$",
+                    UrlTemplate = "https://m4ow.uk/socw/{name}",
+                },
+            };
+
+            using var resolver = new GitHubTdlSourceResolver(
+                http, sources, NullLogger<GitHubTdlSourceResolver>.Instance);
+
+            var url = resolver.Resolve("MOW-SOCW");
+
+            Assert.IsNotNull(url,
+                "Resolver returned null — GitHub may be down or rate-limited.");
+            var pattern = new Regex(@"^https://m4ow\.uk/socw/\d+\.txt$");
+            Assert.IsTrue(pattern.IsMatch(url.ToString()),
+                $"URL '{url}' did not match expected friendly form.");
+            TestContext.WriteLine($"Resolved live URL: {url}");
+        }
+
+        /// <summary>
+        /// Set by MSTest; used to write the resolved URL to test output.
+        /// </summary>
+        public TestContext TestContext { get; set; }
+    }
+}

--- a/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/Services/GitHubTdlSourceResolverTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/Services/GitHubTdlSourceResolverTests.cs
@@ -61,6 +61,43 @@ namespace FiftyOne.DeviceDetection.RobotsTxt.Tests.Services
         };
 
         /// <summary>
+        /// CreateDefault should produce a resolver that already knows
+        /// the canonical MOW-SOCW source from the embedded default
+        /// config — no extra wiring needed.
+        /// </summary>
+        [TestMethod]
+        public void CreateDefault_ReturnsResolverThatKnowsMowSocw()
+        {
+            using var resolver = GitHubTdlSourceResolver.CreateDefault(
+                "TestApp/1.0", NullLoggerFactory.Instance);
+
+            Assert.IsTrue(resolver.IsKnown("MOW-SOCW"));
+        }
+
+        /// <summary>
+        /// Empty User-Agent is rejected — GitHub itself rejects
+        /// requests without a meaningful UA, so we fail fast here.
+        /// </summary>
+        [TestMethod]
+        public void CreateDefault_EmptyUserAgent_Throws()
+        {
+            Assert.ThrowsExactly<ArgumentException>(() =>
+                GitHubTdlSourceResolver.CreateDefault(
+                    "", NullLoggerFactory.Instance));
+        }
+
+        /// <summary>
+        /// Null logger factory is a programmer error.
+        /// </summary>
+        [TestMethod]
+        public void CreateDefault_NullLoggerFactory_Throws()
+        {
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
+                GitHubTdlSourceResolver.CreateDefault(
+                    "TestApp/1.0", null));
+        }
+
+        /// <summary>
         /// IsKnown is a thin wrapper around the configured dictionary;
         /// matched ids report true regardless of casing.
         /// </summary>

--- a/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/Services/GitHubTdlSourceResolverTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/Services/GitHubTdlSourceResolverTests.cs
@@ -1,0 +1,434 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.DeviceDetection.RobotsTxt.Model;
+using FiftyOne.DeviceDetection.RobotsTxt.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Moq.Protected;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FiftyOne.DeviceDetection.RobotsTxt.Tests.Services
+{
+    /// <summary>
+    /// Tests for <see cref="GitHubTdlSourceResolver"/>. The resolver is
+    /// the one piece that actually talks to GitHub, so the tests focus
+    /// on what we promise externally: pick the latest file, do not
+    /// hammer the API, and ride out transient failures by serving the
+    /// last known good URL.
+    /// </summary>
+    [TestClass]
+    public class GitHubTdlSourceResolverTests
+    {
+        private const string SourceId = "MOW-SOCW";
+        private const string ApiBase = "https://api.github.com/";
+
+        private static readonly TdlSource Source = new TdlSource
+        {
+            Id = SourceId,
+            Repository = "movementforanopenweb/terms-documents",
+            Directory = "socw",
+            FilePattern = @"^(?<n>\d+)\.txt$",
+            UrlTemplate = "https://m4ow.uk/socw/{name}",
+        };
+
+        /// <summary>
+        /// IsKnown is a thin wrapper around the configured dictionary;
+        /// matched ids report true regardless of casing.
+        /// </summary>
+        [TestMethod]
+        public void IsKnown_ReturnsTrueForConfiguredSource()
+        {
+            using var resolver = CreateResolver(NeverCalledHandler());
+
+            Assert.IsTrue(resolver.IsKnown(SourceId));
+            Assert.IsTrue(resolver.IsKnown("mow-socw"));
+        }
+
+        /// <summary>
+        /// Anything not in the configured map is unknown — including
+        /// null and empty inputs.
+        /// </summary>
+        [TestMethod]
+        public void IsKnown_ReturnsFalseForUnknownOrEmpty()
+        {
+            using var resolver = CreateResolver(NeverCalledHandler());
+
+            Assert.IsFalse(resolver.IsKnown("UNKNOWN"));
+            Assert.IsFalse(resolver.IsKnown(""));
+            Assert.IsFalse(resolver.IsKnown(null));
+        }
+
+        /// <summary>
+        /// Unknown ids must not generate any HTTP traffic.
+        /// </summary>
+        [TestMethod]
+        public void Resolve_UnknownId_ReturnsNullWithoutHttp()
+        {
+            var handler = NeverCalledHandler();
+            using var resolver = CreateResolver(handler);
+
+            var result = resolver.Resolve("UNKNOWN");
+
+            Assert.IsNull(result);
+            VerifyNoHttp(handler);
+        }
+
+        /// <summary>
+        /// Among files matching the pattern the largest version number
+        /// wins, regardless of the order GitHub returned them in.
+        /// </summary>
+        [TestMethod]
+        public void Resolve_PicksHighestNumberedFile()
+        {
+            var handler = HandlerReturning(
+                File("1.txt"), File("4.txt"), File("2.txt"));
+            using var resolver = CreateResolver(handler);
+
+            var result = resolver.Resolve(SourceId);
+
+            Assert.AreEqual("https://m4ow.uk/socw/4.txt", result.ToString());
+        }
+
+        /// <summary>
+        /// Files that do not match the regex are ignored when picking
+        /// the winner.
+        /// </summary>
+        [TestMethod]
+        public void Resolve_IgnoresNonMatchingNames()
+        {
+            var handler = HandlerReturning(
+                File("README.md"), File("1.txt"), File("draft.txt"));
+            using var resolver = CreateResolver(handler);
+
+            var result = resolver.Resolve(SourceId);
+
+            Assert.AreEqual("https://m4ow.uk/socw/1.txt", result.ToString());
+        }
+
+        /// <summary>
+        /// Directory entries are skipped even if their name happens to
+        /// match the pattern — we only care about real files.
+        /// </summary>
+        [TestMethod]
+        public void Resolve_IgnoresDirectories()
+        {
+            var handler = HandlerReturning(
+                Dir("9.txt"), File("3.txt"));
+            using var resolver = CreateResolver(handler);
+
+            var result = resolver.Resolve(SourceId);
+
+            Assert.AreEqual("https://m4ow.uk/socw/3.txt", result.ToString());
+        }
+
+        /// <summary>
+        /// Empty/no-match listings yield null and do not poison the
+        /// cache (a later success should still be picked up).
+        /// </summary>
+        [TestMethod]
+        public void Resolve_NoMatchingFiles_ReturnsNull()
+        {
+            var handler = HandlerReturning(File("README.md"));
+            using var resolver = CreateResolver(handler);
+
+            var result = resolver.Resolve(SourceId);
+
+            Assert.IsNull(result);
+        }
+
+        /// <summary>
+        /// 4xx/5xx with nothing in the cache means we have nothing to
+        /// hand back. Drop the value so the engine sees no TDL.
+        /// </summary>
+        [TestMethod]
+        public void Resolve_GitHub403_NoCache_ReturnsNull()
+        {
+            var handler = HandlerWithStatus(HttpStatusCode.Forbidden);
+            using var resolver = CreateResolver(handler);
+
+            var result = resolver.Resolve(SourceId);
+
+            Assert.IsNull(result);
+        }
+
+        /// <summary>
+        /// Network errors are treated like any other transient failure:
+        /// no cache yet, so null.
+        /// </summary>
+        [TestMethod]
+        public void Resolve_NetworkException_NoCache_ReturnsNull()
+        {
+            var handler = HandlerThrowing(new HttpRequestException("boom"));
+            using var resolver = CreateResolver(handler);
+
+            var result = resolver.Resolve(SourceId);
+
+            Assert.IsNull(result);
+        }
+
+        /// <summary>
+        /// Once we have a successful result, a later GitHub failure
+        /// must not break callers — we keep handing back the last
+        /// known good URL.
+        /// </summary>
+        [TestMethod]
+        public void Resolve_GitHub403AfterCachedSuccess_ReturnsCached()
+        {
+            var handler = SequencedHandler(
+                JsonResponse(File("4.txt")),
+                StatusResponse(HttpStatusCode.Forbidden));
+
+            var clock = new FakeTimeProvider(DateTimeOffset.UtcNow);
+            var ttl = TimeSpan.FromHours(1);
+            using var resolver = CreateResolver(handler, clock, ttl);
+
+            var first = resolver.Resolve(SourceId);
+            clock.Advance(ttl + TimeSpan.FromMinutes(1));
+            var second = resolver.Resolve(SourceId);
+
+            Assert.AreEqual("https://m4ow.uk/socw/4.txt", first.ToString());
+            Assert.AreEqual("https://m4ow.uk/socw/4.txt", second.ToString());
+        }
+
+        /// <summary>
+        /// Within the TTL window we hold the value and never call
+        /// GitHub again — that's the whole point of the cache.
+        /// </summary>
+        [TestMethod]
+        public void Resolve_CacheHitWithinTtl_NoSecondHttpCall()
+        {
+            var handler = HandlerReturning(File("4.txt"));
+            using var resolver = CreateResolver(handler);
+
+            resolver.Resolve(SourceId);
+            resolver.Resolve(SourceId);
+            resolver.Resolve(SourceId);
+
+            VerifyHttpCount(handler, 1);
+        }
+
+        /// <summary>
+        /// After the TTL elapses we revalidate; a fresh response
+        /// replaces the cached URL.
+        /// </summary>
+        [TestMethod]
+        public void Resolve_CacheExpired_RefreshesAndReturnsNew()
+        {
+            var handler = SequencedHandler(
+                JsonResponse(File("4.txt")),
+                JsonResponse(File("5.txt")));
+
+            var clock = new FakeTimeProvider(DateTimeOffset.UtcNow);
+            var ttl = TimeSpan.FromHours(1);
+            using var resolver = CreateResolver(handler, clock, ttl);
+
+            var first = resolver.Resolve(SourceId);
+            clock.Advance(ttl + TimeSpan.FromMinutes(1));
+            var second = resolver.Resolve(SourceId);
+
+            Assert.AreEqual("https://m4ow.uk/socw/4.txt", first.ToString());
+            Assert.AreEqual("https://m4ow.uk/socw/5.txt", second.ToString());
+            VerifyHttpCount(handler, 2);
+        }
+
+        /// <summary>
+        /// Many parallel callers should result in exactly one trip
+        /// to GitHub — the rest should ride along on the in-flight
+        /// request and the populated cache.
+        /// </summary>
+        [TestMethod]
+        public void Resolve_ConcurrentCalls_SingleHttpCall()
+        {
+            using var gate = new ManualResetEventSlim(initialState: false);
+            var callCount = 0;
+
+            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handler.Protected()
+                .Setup<HttpResponseMessage>(
+                    "Send",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns<HttpRequestMessage, CancellationToken>((req, ct) =>
+                {
+                    Interlocked.Increment(ref callCount);
+                    gate.Wait();
+                    return JsonResponse(File("4.txt"));
+                });
+
+            using var resolver = CreateResolver(handler.Object);
+
+            const int N = 50;
+            var tasks = Enumerable.Range(0, N)
+                .Select(_ => Task.Run(() => resolver.Resolve(SourceId)))
+                .ToArray();
+
+            // Give all callers a chance to queue at the semaphore.
+            Thread.Sleep(50);
+
+            gate.Set();
+            Task.WaitAll(tasks);
+
+            Assert.AreEqual(1, callCount);
+            foreach (var t in tasks)
+            {
+                Assert.AreEqual("https://m4ow.uk/socw/4.txt", t.Result.ToString());
+            }
+        }
+
+        private static GitHubTdlSourceResolver CreateResolver(
+            HttpMessageHandler handler,
+            FakeTimeProvider clock = null,
+            TimeSpan? ttl = null)
+        {
+            var http = new HttpClient(handler) { BaseAddress = new Uri(ApiBase) };
+            var sources = new Dictionary<string, TdlSource>(
+                StringComparer.OrdinalIgnoreCase) { [SourceId] = Source };
+            return new GitHubTdlSourceResolver(
+                http,
+                sources,
+                NullLogger<GitHubTdlSourceResolver>.Instance,
+                clock,
+                ttl);
+        }
+
+        private static (string Name, string Type) File(string name) => (name, "file");
+        private static (string Name, string Type) Dir(string name) => (name, "dir");
+
+        private static HttpResponseMessage JsonResponse(
+            params (string Name, string Type)[] entries)
+        {
+            var json = JsonSerializer.Serialize(
+                entries.Select(e => new { name = e.Name, type = e.Type }));
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    json, Encoding.UTF8, "application/json"),
+            };
+        }
+
+        private static HttpResponseMessage StatusResponse(HttpStatusCode status)
+            => new HttpResponseMessage(status);
+
+        private static HttpMessageHandler HandlerReturning(
+            params (string Name, string Type)[] entries)
+        {
+            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handler.Protected()
+                .Setup<HttpResponseMessage>(
+                    "Send",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns<HttpRequestMessage, CancellationToken>(
+                    (req, ct) => JsonResponse(entries));
+            return handler.Object;
+        }
+
+        private static HttpMessageHandler HandlerWithStatus(HttpStatusCode status)
+        {
+            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handler.Protected()
+                .Setup<HttpResponseMessage>(
+                    "Send",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Returns<HttpRequestMessage, CancellationToken>(
+                    (req, ct) => StatusResponse(status));
+            return handler.Object;
+        }
+
+        private static HttpMessageHandler HandlerThrowing(Exception ex)
+        {
+            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handler.Protected()
+                .Setup<HttpResponseMessage>(
+                    "Send",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Throws(ex);
+            return handler.Object;
+        }
+
+        private static HttpMessageHandler SequencedHandler(
+            params HttpResponseMessage[] responses)
+        {
+            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var setup = handler.Protected()
+                .SetupSequence<HttpResponseMessage>(
+                    "Send",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>());
+            foreach (var r in responses)
+            {
+                setup = setup.Returns(r);
+            }
+            return handler.Object;
+        }
+
+        private static HttpMessageHandler NeverCalledHandler()
+        {
+            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            return handler.Object;
+        }
+
+        private static void VerifyNoHttp(HttpMessageHandler handler)
+        {
+            Mock.Get(handler).Protected()
+                .Verify<HttpResponseMessage>(
+                    "Send",
+                    Times.Never(),
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>());
+        }
+
+        private static void VerifyHttpCount(HttpMessageHandler handler, int expected)
+        {
+            Mock.Get(handler).Protected()
+                .Verify<HttpResponseMessage>(
+                    "Send",
+                    Times.Exactly(expected),
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>());
+        }
+
+        /// <summary>
+        /// Tiny manual <see cref="TimeProvider"/> stand-in. Avoids
+        /// pulling in Microsoft.Extensions.TimeProvider.Testing.
+        /// </summary>
+        private sealed class FakeTimeProvider : TimeProvider
+        {
+            private DateTimeOffset _now;
+            public FakeTimeProvider(DateTimeOffset start) { _now = start; }
+            public override DateTimeOffset GetUtcNow() => _now;
+            public void Advance(TimeSpan delta) { _now += delta; }
+        }
+    }
+}

--- a/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/Services/TdlSourcesLoaderTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/Services/TdlSourcesLoaderTests.cs
@@ -1,0 +1,305 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.DeviceDetection.RobotsTxt.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace FiftyOne.DeviceDetection.RobotsTxt.Tests.Services
+{
+    /// <summary>
+    /// Tests for <see cref="TdlSourcesLoader"/>. The loader is the
+    /// startup gate for tdlSources.json so the bar for validation
+    /// failures throwing is high — they should fail fast rather than
+    /// letting a broken config slip into runtime.
+    /// </summary>
+    [TestClass]
+    public class TdlSourcesLoaderTests
+    {
+        private const string ValidJson = @"
+[
+  {
+    ""Id"": ""MOW-SOCW"",
+    ""Repository"": ""movementforanopenweb/terms-documents"",
+    ""Directory"": ""socw"",
+    ""FilePattern"": ""^(?<n>\\d+)\\.txt$"",
+    ""UrlTemplate"": ""https://m4ow.uk/socw/{name}""
+  }
+]";
+
+        /// <summary>
+        /// The default config shipped with the engine should contain
+        /// the canonical MOW-SOCW source out of the box.
+        /// </summary>
+        [TestMethod]
+        public void LoadDefault_ReturnsEmbeddedSourcesWithMowSocw()
+        {
+            var result = TdlSourcesLoader.LoadDefault();
+
+            Assert.IsTrue(result.ContainsKey("MOW-SOCW"));
+            var entry = result["MOW-SOCW"];
+            Assert.AreEqual("movementforanopenweb/terms-documents", entry.Repository);
+            Assert.AreEqual("socw", entry.Directory);
+            Assert.AreEqual("https://m4ow.uk/socw/{name}", entry.UrlTemplate);
+        }
+
+        /// <summary>
+        /// Lookups against the embedded default ignore case so callers
+        /// don't have to match the JSON's exact casing.
+        /// </summary>
+        [TestMethod]
+        public void LoadDefault_LookupIsCaseInsensitive()
+        {
+            var result = TdlSourcesLoader.LoadDefault();
+
+            Assert.IsTrue(result.ContainsKey("mow-socw"));
+            Assert.IsTrue(result.ContainsKey("Mow-SoCw"));
+        }
+
+        /// <summary>
+        /// Happy path for the file overload: a single well-formed
+        /// entry yields a one-key dictionary with the original
+        /// values intact.
+        /// </summary>
+        [TestMethod]
+        public void LoadFromFile_ValidSource_ReturnsDictionaryKeyedById()
+        {
+            var path = System.IO.Path.GetTempFileName();
+            try
+            {
+                File.WriteAllText(path, ValidJson);
+
+                var result = TdlSourcesLoader.LoadFromFile(path);
+
+                Assert.HasCount(1, result);
+                Assert.IsTrue(result.ContainsKey("MOW-SOCW"));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        /// <summary>
+        /// Missing file is a deployment problem; surface a
+        /// <see cref="FileNotFoundException"/> so the cause is obvious
+        /// in startup logs.
+        /// </summary>
+        [TestMethod]
+        public void LoadFromFile_FileMissing_ThrowsFileNotFound()
+        {
+            var path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"missing-{Guid.NewGuid():N}.json");
+
+            Assert.ThrowsExactly<FileNotFoundException>(
+                () => TdlSourcesLoader.LoadFromFile(path));
+        }
+
+        /// <summary>
+        /// Empty path is a programmer error.
+        /// </summary>
+        [TestMethod]
+        public void LoadFromFile_EmptyPath_Throws()
+        {
+            Assert.ThrowsExactly<ArgumentException>(
+                () => TdlSourcesLoader.LoadFromFile(""));
+        }
+
+        /// <summary>
+        /// Null input to the in-memory overload is a programmer error.
+        /// </summary>
+        [TestMethod]
+        public void LoadFromJson_NullJson_Throws()
+        {
+            Assert.ThrowsExactly<ArgumentNullException>(
+                () => TdlSourcesLoader.LoadFromJson(null));
+        }
+
+        /// <summary>
+        /// An empty array is a valid (if pointless) config and should
+        /// not throw.
+        /// </summary>
+        [TestMethod]
+        public void LoadFromJson_EmptyArray_ReturnsEmptyDictionary()
+        {
+            var result = TdlSourcesLoader.LoadFromJson("[]");
+
+            Assert.IsEmpty(result);
+        }
+
+        /// <summary>
+        /// JSON that is not parseable should be wrapped in
+        /// <see cref="InvalidOperationException"/> with the underlying
+        /// JsonException kept as inner exception.
+        /// </summary>
+        [TestMethod]
+        public void LoadFromJson_MalformedJson_Throws()
+        {
+            var ex = Assert.ThrowsExactly<InvalidOperationException>(
+                () => TdlSourcesLoader.LoadFromJson("{ not json"));
+            Assert.IsNotNull(ex.InnerException);
+        }
+
+        /// <summary>
+        /// Top-level JSON 'null' deserialises to a null list and is
+        /// rejected with a clear message.
+        /// </summary>
+        [TestMethod]
+        public void LoadFromJson_JsonNullArray_Throws()
+        {
+            Assert.ThrowsExactly<InvalidOperationException>(
+                () => TdlSourcesLoader.LoadFromJson("null"));
+        }
+
+        /// <summary>
+        /// A null element inside the array is rejected — the index in
+        /// the message helps the author find it.
+        /// </summary>
+        [TestMethod]
+        public void LoadFromJson_NullElement_Throws()
+        {
+            var ex = Assert.ThrowsExactly<InvalidOperationException>(
+                () => TdlSourcesLoader.LoadFromJson("[null]"));
+            StringAssert.Contains(ex.Message, "index 0");
+        }
+
+        /// <summary>
+        /// Each required field must be non-empty; missing Id is the
+        /// representative case.
+        /// </summary>
+        [TestMethod]
+        public void LoadFromJson_MissingId_Throws()
+        {
+            var json = @"
+[
+  {
+    ""Repository"": ""x/y"",
+    ""Directory"": ""d"",
+    ""FilePattern"": ""^(?<n>\\d+)$"",
+    ""UrlTemplate"": ""https://x/{name}""
+  }
+]";
+            var ex = Assert.ThrowsExactly<InvalidOperationException>(
+                () => TdlSourcesLoader.LoadFromJson(json));
+            StringAssert.Contains(ex.Message, "Id");
+        }
+
+        /// <summary>
+        /// A FilePattern that is not a compilable regex must surface
+        /// the original ArgumentException as inner.
+        /// </summary>
+        [TestMethod]
+        public void LoadFromJson_InvalidRegex_Throws()
+        {
+            var json = @"
+[
+  {
+    ""Id"": ""X"",
+    ""Repository"": ""x/y"",
+    ""Directory"": ""d"",
+    ""FilePattern"": ""[unclosed"",
+    ""UrlTemplate"": ""https://x/{name}""
+  }
+]";
+            var ex = Assert.ThrowsExactly<InvalidOperationException>(
+                () => TdlSourcesLoader.LoadFromJson(json));
+            Assert.IsInstanceOfType(ex.InnerException, typeof(ArgumentException));
+        }
+
+        /// <summary>
+        /// FilePattern without the named version group cannot be used
+        /// to pick the latest file, so it is rejected.
+        /// </summary>
+        [TestMethod]
+        public void LoadFromJson_PatternMissingNamedGroup_Throws()
+        {
+            var json = @"
+[
+  {
+    ""Id"": ""X"",
+    ""Repository"": ""x/y"",
+    ""Directory"": ""d"",
+    ""FilePattern"": ""^\\d+\\.txt$"",
+    ""UrlTemplate"": ""https://x/{name}""
+  }
+]";
+            var ex = Assert.ThrowsExactly<InvalidOperationException>(
+                () => TdlSourcesLoader.LoadFromJson(json));
+            StringAssert.Contains(ex.Message, "named group");
+        }
+
+        /// <summary>
+        /// Without the {name} placeholder the loader cannot build the
+        /// final URL, so we reject the entry rather than silently
+        /// returning a malformed link at runtime.
+        /// </summary>
+        [TestMethod]
+        public void LoadFromJson_UrlTemplateMissingPlaceholder_Throws()
+        {
+            var json = @"
+[
+  {
+    ""Id"": ""X"",
+    ""Repository"": ""x/y"",
+    ""Directory"": ""d"",
+    ""FilePattern"": ""^(?<n>\\d+)$"",
+    ""UrlTemplate"": ""https://x/static.txt""
+  }
+]";
+            var ex = Assert.ThrowsExactly<InvalidOperationException>(
+                () => TdlSourcesLoader.LoadFromJson(json));
+            StringAssert.Contains(ex.Message, "{name}");
+        }
+
+        /// <summary>
+        /// Two entries with the same Id (even differing in case) are
+        /// ambiguous; reject so the author resolves the conflict.
+        /// </summary>
+        [TestMethod]
+        public void LoadFromJson_DuplicateId_Throws()
+        {
+            var json = @"
+[
+  {
+    ""Id"": ""X"",
+    ""Repository"": ""a/b"",
+    ""Directory"": ""d"",
+    ""FilePattern"": ""^(?<n>\\d+)$"",
+    ""UrlTemplate"": ""https://x/{name}""
+  },
+  {
+    ""Id"": ""x"",
+    ""Repository"": ""c/d"",
+    ""Directory"": ""d"",
+    ""FilePattern"": ""^(?<n>\\d+)$"",
+    ""UrlTemplate"": ""https://y/{name}""
+  }
+]";
+            var ex = Assert.ThrowsExactly<InvalidOperationException>(
+                () => TdlSourcesLoader.LoadFromJson(json));
+            StringAssert.Contains(ex.Message, "Duplicate");
+        }
+
+    }
+}


### PR DESCRIPTION
### **Why:**

- [RobotsTxt: generic sources + auto-discover the latest terms URL for various sources](https://github.com/51Degrees/cloud/issues/47)

### **Changes:**
Adds a Services-layer plug-in to `RobotsTxtEngine` that maps short TDL identifiers in `query.robotstxt.tdl` evidence to URLs before the engine emits its `TDL:` lines. The default config (currently MOW-SOCW) is embedded in the engine assembly, and a default GitHub-backed resolver is attached by the builder out of the box — so consumers that just list the engine in pipeline configuration get short-id resolution with no extra wiring.
```
?robotstxt.tdl=MOW-SOCW
```
becomes
```
TDL: https://m4ow.uk/socw/<n>.txt
```
`<n>` - is the highest-numbered file


**Resolver kicks in only when `Uri.TryCreate` fails.** Existing callers passing absolute URIs see no behaviour change.
**Loader stays out of the engine's HTTP layer.** Consumers wanting sources from JSON, env vars, or a DB write their own loader; the engine just takes the dictionary.
**No GitHub auth.** Unauthenticated limit is 60/h per IP; with a 12 h cache TTL we use ~2 calls/day per source. Adding a secret dependency to back off from a non-existent ceiling didn't seem worth it.

The hooks are additive. Existing code that ignores the new methods keeps the previous contract for absolute URIs; the only visible behaviour change is that **non-URI values** in `query.robotstxt.tdl` that were silently dropped before may now resolve to URLs (when they match a configured short id).