### PR TITLE
FEAT: annotate each TDL line with a "# Terms <url>" comment

### DIFF
--- a/FiftyOne.DeviceDetection.RobotsTxt/Services/GeneratorService.cs
+++ b/FiftyOne.DeviceDetection.RobotsTxt/Services/GeneratorService.cs
@@ -141,8 +141,11 @@ public class GeneratorService(RobotsTxtModel _dataSet)
         writer.WriteLine("User-Agent: *");
         foreach (var tdl in tdls)
         {
+            var url = tdl.ToString();
+            writer.Write("# Terms ");
+            writer.WriteLine(url);
             writer.Write("TDL: ");
-            writer.WriteLine(tdl.ToString());
+            writer.WriteLine(url);
         }
         writer.WriteLine("Allow: /");
     }

--- a/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/RobotsTxtTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/RobotsTxtTests.cs
@@ -309,5 +309,30 @@ namespace FiftyOne.DeviceDetection.RobotsTxt.Tests
             Assert.Contains("User-Agent: *", plain);
             Assert.Contains("Disallow: /", plain);
         }
+
+        /// <summary>
+        /// Checks that each TDL URI is preceded by a human-readable
+        /// "# Terms &lt;url&gt;" comment line so readers of the
+        /// generated robots.txt can see what the TDL points at without
+        /// having to know the spec.
+        /// </summary>
+        [TestMethod]
+        public void TdlEachUriPrecededByTermsComment()
+        {
+            // Arrange
+            const string url1 = "https://example.com/terms-v1";
+            const string url2 = "https://custom.terms/terms.txt";
+            _data.AddEvidence(Constants.TdlEvidenceKey, $"{url1},{url2}");
+
+            // Act
+            _data.Process();
+
+            // Assert
+            var result = _data.Get<IRobotsTxtData>();
+            Assert.IsTrue(result.PlainText.HasValue);
+            var plain = result.PlainText.Value.Replace("\r\n", "\n");
+            Assert.Contains($"# Terms {url1}\nTDL: {url1}", plain);
+            Assert.Contains($"# Terms {url2}\nTDL: {url2}", plain);
+        }
     }
 }


### PR DESCRIPTION
Small follow-up to the existing TDL footer in `RobotsTxtEngine`. Each TDL URI now gets a human-readable `# Terms <url>` comment line right before the corresponding `TDL:` line.

Before:
```
User-Agent: *
TDL: https://m4ow.uk/socw/1.txt
TDL: https://custom.terms/terms.txt
Allow: /
```
After: 
```
User-Agent: *
# Terms https://m4ow.uk/socw/1.txt
TDL: https://m4ow.uk/socw/1.txt
# Terms https://custom.terms/terms.txt
TDL: https://custom.terms/terms.txt
Allow: / 
```                              