### PR TITLE
Add a simple model for RobotsTxt plain and annotated text json response

### DIFF
--- a/FiftyOne.DeviceDetection.RobotsTxt/FlowElements/RobotsTxtEngine.cs
+++ b/FiftyOne.DeviceDetection.RobotsTxt/FlowElements/RobotsTxtEngine.cs
@@ -206,7 +206,7 @@ namespace FiftyOne.DeviceDetection.RobotsTxt.FlowElements
             var usages = GetUsages(engine).ToArray();
             var crawlers = GetCrawlers(
                 _queryService.Query(contextPipeline)).ToArray();
-            _generatorService = new GeneratorService(new RobotsTxtModel()
+            _generatorService = new GeneratorService(new CrawlerUsageModel()
             {
                 Crawlers = crawlers,
                 Usages = usages

--- a/FiftyOne.DeviceDetection.RobotsTxt/Model/CrawlerUsageModel.cs
+++ b/FiftyOne.DeviceDetection.RobotsTxt/Model/CrawlerUsageModel.cs
@@ -20,36 +20,17 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
-using System;
-
 namespace FiftyOne.DeviceDetection.RobotsTxt.Model;
 
 /// <summary>
-/// Details associated with each crawler. Used both for extraction and then 
-/// refinement.
+/// A model for all the data needed to work with Robots.Txt. Provided in JSON
+/// format from a transformation of Daphne data.
 /// </summary>
-public class CrawlerModel
+public class CrawlerUsageModel
 {
     /// <summary>
-    /// The name of the crawler. Relates to the CrawlerName property.
+    /// A list of the possible usages in the order which they should be shown
+    /// in UIs and reports.
     /// </summary>
-    public string Name {  get; set; }
-
-    /// <summary>
-    /// Array of usage names that must be available in 
-    /// <see cref="UsageModel.Name"/> that this crawler is associated
-    /// with. Used to work out how to treat the User-Agent in the robots.txt
-    /// file.
-    /// </summary>
-    public string[] Usages { get; set; }
-
-    /// <summary>
-    /// Product tokens.
-    /// </summary>
-    public string[] ProductTokens { get; set; }
-
-    /// <summary>
-    /// Reference URIs.
-    /// </summary>
-    public Uri[] ReferenceUris { get; set; }
+    public UsageModel[] Usages { get; set; }
 }

--- a/FiftyOne.DeviceDetection.RobotsTxt/Model/RobotsTxtModel.cs
+++ b/FiftyOne.DeviceDetection.RobotsTxt/Model/RobotsTxtModel.cs
@@ -23,19 +23,18 @@
 namespace FiftyOne.DeviceDetection.RobotsTxt.Model;
 
 /// <summary>
-/// A model for all the data needed to work with Robots.Txt. Provided in JSON
-/// format from a transformation of Daphne data.
+/// A model for Robots.Txt. Provided in JSON
+/// format.
 /// </summary>
 public class RobotsTxtModel
 {
     /// <summary>
-    /// A list of the crawlers that are available.
+    /// See <see cref="Messages.PlainTextDescription"/>
     /// </summary>
-    public CrawlerModel[] Crawlers { get; set; }
+    public string PlainText { get; set; }
 
     /// <summary>
-    /// A list of the possible usages in the order which they should be shown
-    /// in UIs and reports.
+    /// See <see cref="Messages.AnnotatedTextDescription"/>
     /// </summary>
-    public UsageModel[] Usages { get; set; }
+    public string AnnotatedText { get; set; }
 }

--- a/FiftyOne.DeviceDetection.RobotsTxt/Services/GeneratorService.cs
+++ b/FiftyOne.DeviceDetection.RobotsTxt/Services/GeneratorService.cs
@@ -30,7 +30,7 @@ using System.Threading;
 
 namespace FiftyOne.DeviceDetection.RobotsTxt.Services;
 
-public class GeneratorService(RobotsTxtModel _dataSet)
+public class GeneratorService(CrawlerUsageModel _dataSet)
 {
     /// <summary>
     /// Builds a robots.txt with or without annotations for the choices


### PR DESCRIPTION
FEAT: Add simple model for RobotsTxt plain and annotated in the instance we want to deserialize from cloud response json.
CLEANUP: Rename the current RobotsTxtModel to CrawlerUsageModel as that name is more appropriate.