### PR TITLE
FIX: Scope hardware.Profiles.ItemProperties to indexed-key components and stamp ProfileId on resolved profiles

### DIFF
--- a/FiftyOne.DeviceDetection.PropertyKeyed/Data/MultiDeviceData.cs
+++ b/FiftyOne.DeviceDetection.PropertyKeyed/Data/MultiDeviceData.cs
@@ -20,6 +20,7 @@
  * such notice(s) shall fulfill the requirements of that article.
  * ********************************************************************* */
 
+using FiftyOne.DeviceDetection.PropertyKeyed.Services;
 using FiftyOne.Pipeline.Core.FlowElements;
 using FiftyOne.Pipeline.Engines.Data;
 using FiftyOne.Pipeline.Engines.FlowElements;
@@ -142,6 +143,20 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Data
                 var deviceData = flowData.Get<IDeviceData>();
                 if (deviceData != null)
                 {
+                    // The profile is identified by its ProfileId — that's
+                    // the detection result. The hash engine populates only
+                    // value-surface properties (IsMobile, ScreenPixels…)
+                    // declared in engine.Properties; the id lives on the
+                    // identity surface (IProfileMetaData.ProfileId) and
+                    // never gets written into the per-profile data dict.
+                    // Stamp it here so consumers can correlate the profile
+                    // entry with the rest of the value collection it owns.
+                    deviceData[DataSetService.PROFILE_ID_PROPERTY_NAME] =
+                        new AspectPropertyValue<string>(
+                            profileId.ToString(
+                                System.Globalization.CultureInfo
+                                    .InvariantCulture));
+
                     result.Add(deviceData);
 
                     // Track for disposal

--- a/FiftyOne.DeviceDetection.PropertyKeyed/Services/DataSetService.cs
+++ b/FiftyOne.DeviceDetection.PropertyKeyed/Services/DataSetService.cs
@@ -101,12 +101,27 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Services
                 ProcessProfile(item, indexes);
             }
 
-            // Collect all engine properties to expose as sub-properties
-            // of "Profiles". Each is wrapped with DevicePropertyMetaData
-            // that re-associates the property with the outer
-            // property-keyed engine instead of the inner
-            // DeviceDetectionHashEngine.
+            // Collect engine properties to expose as sub-properties of
+            // "Profiles". Each is wrapped with DevicePropertyMetaData that
+            // re-associates the property with the outer property-keyed
+            // engine instead of the inner DeviceDetectionHashEngine.
+            //
+            // Scope by the components of the indexed key properties so the
+            // surface includes only properties that actually live on the
+            // matched profiles — TAC's component is HardwarePlatform, so
+            // a TacEngine exposes hardware-classification properties and
+            // not browser/platform/JS ones. Mirrors the same component
+            // filter PropertyValueQueryService.Query already uses to pick
+            // which profiles to populate.
+            var relevantComponents = _queryService.IndexedProperties
+                .Select(name => propertyLookup.TryGetValue(name, out var m)
+                    ? m.Component
+                    : null)
+                .Where(c => c != null)
+                .ToHashSet();
+
             var profileProperties = engine.Properties
+                .Where(p => relevantComponents.Contains(p.Component))
                 .Select(p => (IFiftyOneAspectPropertyMetaData)
                     new DevicePropertyMetaData(element, p))
                 .ToList()


### PR DESCRIPTION
## Summary
- `DataSetService.BuildDataSet` now scopes `engine.Properties` to the components of the indexed key properties before exposing them as `Profiles.ItemProperties`. Mirrors the filter `PropertyValueQueryService.Query` already uses, so a `TacEngine` (key=`TAC`, component=`HardwarePlatform`) only surfaces hardware-classification properties not the browser/platform/JS/CSS/crawler properties that PR #726 inadvertently let through.
- `MultiDeviceData.ResolveProfiles` stamps `deviceData["ProfileId"]` on each resolved per-profile `IDeviceData` from the `_profileIds` loop variable. The synthetic `ProfileId` leaf added by PR #744 had metadata but no runtime population, so the cloud's JSON builder was emitting `profileid: null` plus a misleading "is a paid feature" `nullreason`.

## Effect on cloud `accessibleproperties`

`hardware.Profiles.ItemProperties` for a TAC resource key does not expose unneeded properties (s.a. browser, platform etc), `ProfileId` is now emitted with the actual profile id.