### PR TITLE
FIX: Add unit tests for `GeneratorService` ensuring correct annotated and plain-text output for allowed crawlers, TDL handling, and wildcard block behavior

### DIFF
--- a/FiftyOne.DeviceDetection.RobotsTxt/Services/GeneratorService.cs
+++ b/FiftyOne.DeviceDetection.RobotsTxt/Services/GeneratorService.cs
@@ -63,6 +63,7 @@ public class GeneratorService(RobotsTxtModel _dataSet)
         CancellationToken stopToken)
     {
         var disallowEntries = new Queue<string>();
+        var allowedCrawlers = new List<CrawlerModel>();
         foreach (var crawler in _dataSet.Crawlers.OrderBy(i => i.Name))
         {
             if (GetIsAllowed(crawler, allowed) == false)
@@ -70,6 +71,10 @@ public class GeneratorService(RobotsTxtModel _dataSet)
                 Add(disallowEntries, crawler, annotations ?
                     sb => AddAnnotations(crawler, sb) :
                     null);
+            }
+            else
+            {
+                allowedCrawlers.Add(crawler);
             }
         }
 
@@ -90,29 +95,44 @@ public class GeneratorService(RobotsTxtModel _dataSet)
             writer.WriteLine();
         }
 
-        // Wildcard catch-all is always Allow. When TDL URIs are provided each
-        // is emitted as a TDL line preceded by a "# Terms ..." comment.
-        if (tdls != null && tdls.Count > 0)
-        {
-            AddTdlFooter(writer, tdls);
-        }
-        else
-        {
-            AddFooter(writer);
-        }
+        WriteWildcardBlock(writer, allowedCrawlers, tdls, annotations);
     }
 
-    private static void AddTdlFooter(TextWriter writer, IReadOnlyList<Uri> tdls)
+    // Writes the wildcard catch-all that closes the file. It is always an Allow
+    // block. In annotated output the crawlers that fall through to it (the
+    // allowed crawlers) are listed as one comment group before the Allow record,
+    // followed by any TDL lines. PlainText omits the crawler comments so it stays
+    // a clean directive file.
+    private void WriteWildcardBlock(
+        TextWriter writer,
+        IReadOnlyList<CrawlerModel> allowedCrawlers,
+        IReadOnlyList<Uri> tdls,
+        bool annotations)
     {
         writer.WriteLine("User-Agent: *");
-        foreach (var tdl in tdls)
+
+        if (annotations)
         {
-            var url = tdl.ToString();
-            writer.Write("# Terms ");
-            writer.WriteLine(url);
-            writer.Write("TDL: ");
-            writer.WriteLine(url);
+            var sb = new StringBuilder();
+            foreach (var crawler in allowedCrawlers)
+            {
+                AddAnnotations(crawler, sb);
+            }
+            writer.Write(sb.ToString());
         }
+
+        if (tdls != null && tdls.Count > 0)
+        {
+            foreach (var tdl in tdls)
+            {
+                var url = tdl.ToString();
+                writer.Write("# Terms ");
+                writer.WriteLine(url);
+                writer.Write("TDL: ");
+                writer.WriteLine(url);
+            }
+        }
+
         writer.WriteLine("Allow: /");
     }
 
@@ -174,12 +194,6 @@ public class GeneratorService(RobotsTxtModel _dataSet)
         sb.WriteLine("# TDL: Terms Document Locator (immutable terms URL applied to the Allow block)");
         sb.WriteLine("# See https://51degrees.com/robots-txt for further details");
         sb.WriteLine();
-    }
-
-    private static void AddFooter(TextWriter sb)
-    {
-        sb.WriteLine("User-Agent: *");
-        sb.WriteLine("Allow: /");
     }
 
     private static void AddAnnotations(CrawlerModel crawler, StringBuilder sb)

--- a/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/GeneratorServiceTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/GeneratorServiceTests.cs
@@ -1,0 +1,211 @@
+using FiftyOne.DeviceDetection.RobotsTxt.Model;
+using FiftyOne.DeviceDetection.RobotsTxt.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace FiftyOne.DeviceDetection.RobotsTxt.Tests
+{
+    /// <summary>
+    /// Direct tests for <see cref="GeneratorService"/> output. The model is
+    /// built by hand so these run without a data file.
+    /// </summary>
+    [TestClass]
+    public class GeneratorServiceTests
+    {
+        private static GeneratorService BuildGenerator()
+        {
+            var model = new RobotsTxtModel
+            {
+                Usages = new[]
+                {
+                    new UsageModel { Name = "Search", Order = 0 },
+                    new UsageModel { Name = "AI", Order = 1 },
+                    new UsageModel { Name = "Monitoring", Order = 2 },
+                },
+                Crawlers = new[]
+                {
+                    new CrawlerModel
+                    {
+                        Name = "Googlebot",
+                        Usages = new[] { "Search" },
+                        ProductTokens = new[] { "Googlebot" },
+                        ReferenceUris = new[]
+                        {
+                            new Uri("https://developers.google.com/search/docs/crawling-indexing/googlebot"),
+                        },
+                    },
+                    new CrawlerModel
+                    {
+                        Name = "GPTBot",
+                        Usages = new[] { "AI" },
+                        ProductTokens = new[] { "GPTBot" },
+                        ReferenceUris = new[] { new Uri("https://platform.openai.com/docs/gptbot") },
+                    },
+                    new CrawlerModel
+                    {
+                        Name = "BingBot",
+                        Usages = new[] { "Search", "Monitoring" },
+                        ProductTokens = new[] { "bingbot", "BingPreview" },
+                        ReferenceUris = null,
+                    },
+                    new CrawlerModel
+                    {
+                        Name = "AhrefsBot",
+                        Usages = new[] { "Monitoring" },
+                        ProductTokens = new[] { "AhrefsBot" },
+                        ReferenceUris = new[] { new Uri("https://ahrefs.com/robot") },
+                    },
+                },
+            };
+            return new GeneratorService(model);
+        }
+
+        private static string Generate(
+            GeneratorService gen,
+            HashSet<string> allowed,
+            IReadOnlyList<Uri> tdls,
+            bool annotations)
+        {
+            var sb = new StringBuilder();
+            using (var writer = new StringWriter(sb))
+            {
+                gen.Write(writer, allowed, tdls, annotations, CancellationToken.None);
+            }
+            return sb.ToString().Replace("\r\n", "\n");
+        }
+
+        // The wildcard catch-all is the only block that uses "User-Agent: *".
+        private static string WildcardBlock(string text)
+        {
+            var i = text.IndexOf("User-Agent: *", StringComparison.Ordinal);
+            Assert.IsGreaterThanOrEqualTo(0, i, "Expected a wildcard 'User-Agent: *' block");
+            return text.Substring(i);
+        }
+
+        // Non-comment "records": User-Agent / Disallow / Allow / TDL lines only.
+        private static string Records(string text) =>
+            string.Join(
+                "\n",
+                text.Split('\n')
+                    .Select(line => line.Trim())
+                    .Where(line => line.Length > 0 && line.StartsWith("#") == false));
+
+        [TestMethod]
+        public void AnnotatedText_AllowedCrawlers_LumpedInWildcardBlock()
+        {
+            var gen = BuildGenerator();
+
+            var text = Generate(
+                gen,
+                new HashSet<string> { "Search" },
+                Array.Empty<Uri>(),
+                annotations: true);
+
+            var wildcard = WildcardBlock(text);
+
+            Assert.Contains("# N: BingBot", wildcard);
+            Assert.Contains("# N: Googlebot", wildcard);
+            Assert.DoesNotContain("Disallow:", wildcard);
+
+            var bing = wildcard.IndexOf("# N: BingBot", StringComparison.Ordinal);
+            var google = wildcard.IndexOf("# N: Googlebot", StringComparison.Ordinal);
+            var allow = wildcard.IndexOf("Allow: /", StringComparison.Ordinal);
+            Assert.IsLessThan(google, bing, "Allowed crawlers should be ordered by name");
+            Assert.IsLessThan(allow, google, "Allowed-crawler comments must precede the Allow record");
+
+            // Disallowed crawlers stay above the wildcard block (not mixed in).
+            Assert.DoesNotContain("# N: AhrefsBot", wildcard);
+            Assert.DoesNotContain("# N: GPTBot", wildcard);
+        }
+
+        [TestMethod]
+        public void PlainText_AllowedCrawlers_NotAnnotated()
+        {
+            var gen = BuildGenerator();
+
+            var text = Generate(
+                gen,
+                new HashSet<string> { "Search" },
+                Array.Empty<Uri>(),
+                annotations: false);
+
+            Assert.DoesNotContain("# N:", text, "PlainText must not annotate crawlers");
+            Assert.AreEqual(
+                "User-Agent: *\nAllow: /\n",
+                WildcardBlock(text),
+                "PlainText wildcard block must stay a bare Allow");
+        }
+
+        [TestMethod]
+        public void AnnotatedText_AllowedLump_PrecedesTdlPairs()
+        {
+            var gen = BuildGenerator();
+            var tdls = new[]
+            {
+                new Uri("https://example.com/terms-v1"),
+                new Uri("https://example.com/terms-v2"),
+            };
+
+            var text = Generate(gen, new HashSet<string> { "Search" }, tdls, annotations: true);
+            var wildcard = WildcardBlock(text);
+
+            Assert.Contains("# N: BingBot", wildcard);
+            Assert.Contains("# N: Googlebot", wildcard);
+
+            var google = wildcard.IndexOf("# N: Googlebot", StringComparison.Ordinal);
+            var terms1 = wildcard.IndexOf("# Terms https://example.com/terms-v1", StringComparison.Ordinal);
+            var tdl1 = wildcard.IndexOf("TDL: https://example.com/terms-v1", StringComparison.Ordinal);
+            var terms2 = wildcard.IndexOf("# Terms https://example.com/terms-v2", StringComparison.Ordinal);
+            var allow = wildcard.IndexOf("Allow: /", StringComparison.Ordinal);
+
+            Assert.IsLessThan(terms1, google, "Allowed-crawler comments precede TDL lines");
+            Assert.IsLessThan(tdl1, terms1, "Each # Terms comment precedes its TDL record (as in PlainText)");
+            Assert.IsLessThan(terms2, tdl1, "TDL entries preserve input order");
+            Assert.IsLessThan(allow, terms2, "TDL lines precede the Allow record");
+        }
+
+        [TestMethod]
+        public void Records_IdenticalBetweenPlainAndAnnotated()
+        {
+            var gen = BuildGenerator();
+            var allowed = new HashSet<string> { "Search" };
+            var tdls = new[]
+            {
+                new Uri("https://example.com/terms-v1"),
+                new Uri("https://example.com/terms-v2"),
+            };
+
+            var plain = Generate(gen, allowed, tdls, annotations: false);
+            var annotated = Generate(gen, allowed, tdls, annotations: true);
+
+            Assert.AreEqual(
+                Records(plain),
+                Records(annotated),
+                "Non-comment records must match between PlainText and AnnotatedText");
+        }
+
+        [TestMethod]
+        public void AnnotatedText_NoAllowedCrawlers_NoLump()
+        {
+            var gen = BuildGenerator();
+
+            // Nothing allowed -> every crawler becomes a Disallow block; the
+            // wildcard block has no allowed crawlers to list.
+            var text = Generate(
+                gen,
+                new HashSet<string>(),
+                Array.Empty<Uri>(),
+                annotations: true);
+
+            Assert.AreEqual(
+                "User-Agent: *\nAllow: /\n",
+                WildcardBlock(text),
+                "With no allowed crawlers the wildcard block is a bare Allow");
+        }
+    }
+}


### PR DESCRIPTION
### **Why:**

- https://github.com/51Degrees/device-detection-dotnet/issues/769