### PR TITLE
Align resource key environment variable

### DIFF
--- a/.github/workflows/data-file-change.yml
+++ b/.github/workflows/data-file-change.yml
@@ -17,5 +17,5 @@ jobs:
       dryrun: ${{ inputs.dryrun || false }}
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
-      data-key: ${{ secrets.DEVICE_DETECTION_KEY }}
+      data-key: ${{ secrets._51DEGREES_LICENSE_KEY_CLOUDV5PRO }}
       data-url: ${{ secrets.DEVICE_DETECTION_URL }}

--- a/.github/workflows/nightly-pipeline.yml
+++ b/.github/workflows/nightly-pipeline.yml
@@ -19,7 +19,7 @@ jobs:
       dryrun: ${{ inputs.dryrun || false }}
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
-      data-key: ${{ secrets.DEVICE_DETECTION_KEY }}
+      data-key: ${{ secrets._51DEGREES_LICENSE_KEY_CLOUDV5PRO }}
       data-url: ${{ secrets.DEVICE_DETECTION_URL }}
 
   PackageUpdate:
@@ -54,10 +54,9 @@ jobs:
       cache-assets: true
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
-      DeviceDetection: ${{ secrets.DEVICE_DETECTION_KEY }}
+      DeviceDetection: ${{ secrets._51DEGREES_LICENSE_KEY_CLOUDV5PRO }}
       DeviceDetectionUrl: ${{ secrets.DEVICE_DETECTION_URL }}
-      TestResourceKey: ${{ secrets.SUPER_RESOURCE_KEY}}
-      ResourceKeyCloudV5Bespoke: ${{ secrets.RESOURCE_KEY_CLOUD_V5_BESPOKE }}
+      TestResourceKey: ${{ secrets._51DEGREES_RESOURCE_KEY_BESPOKE }}
       AcceptCHBrowserKey: ${{ secrets.ACCEPTCH_BROWSER_KEY}}
       AcceptCHHardwareKey: ${{ secrets.ACCEPTCH_HARDWARE_KEY}}
       AcceptCHPlatformKey: ${{ secrets.ACCEPTCH_PLATFORM_KEY}}
@@ -84,10 +83,9 @@ jobs:
       CodeSigningKeyVaultClientSecret: ${{ secrets.CODE_SIGNING_KEY_VAULT_CLIENT_SECRET }}
       CodeSigningKeyVaultCertificateName: ${{ secrets.CODE_SIGNING_KEY_VAULT_CERTIFICATE_NAME }}
       StrongNameKeyBase64: ${{ secrets.STRONG_NAME_KEY_BASE64 }}
-      DeviceDetection: ${{ secrets.DEVICE_DETECTION_KEY }}
+      DeviceDetection: ${{ secrets._51DEGREES_LICENSE_KEY_CLOUDV5PRO }}
       DeviceDetectionUrl: ${{ secrets.DEVICE_DETECTION_URL }}
-      TestResourceKey: ${{ secrets.SUPER_RESOURCE_KEY}}
-      ResourceKeyCloudV5Bespoke: ${{ secrets.RESOURCE_KEY_CLOUD_V5_BESPOKE }}
+      TestResourceKey: ${{ secrets._51DEGREES_RESOURCE_KEY_BESPOKE }}
       AcceptCHBrowserKey: ${{ secrets.ACCEPTCH_BROWSER_KEY}}
       AcceptCHHardwareKey: ${{ secrets.ACCEPTCH_HARDWARE_KEY}}
       AcceptCHPlatformKey: ${{ secrets.ACCEPTCH_PLATFORM_KEY}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,10 +26,9 @@ jobs:
       CodeSigningKeyVaultClientSecret: ${{ secrets.CODE_SIGNING_KEY_VAULT_CLIENT_SECRET }}
       CodeSigningKeyVaultCertificateName: ${{ secrets.CODE_SIGNING_KEY_VAULT_CERTIFICATE_NAME }}
       StrongNameKeyBase64: ${{ secrets.STRONG_NAME_KEY_BASE64 }}
-      DeviceDetection: ${{ secrets.DEVICE_DETECTION_KEY }}
+      DeviceDetection: ${{ secrets._51DEGREES_LICENSE_KEY_CLOUDV5PRO }}
       DeviceDetectionUrl: ${{ secrets.DEVICE_DETECTION_URL }}
-      TestResourceKey: ${{ secrets.SUPER_RESOURCE_KEY}}
-      ResourceKeyCloudV5Bespoke: ${{ secrets.RESOURCE_KEY_CLOUD_V5_BESPOKE }}
+      TestResourceKey: ${{ secrets._51DEGREES_RESOURCE_KEY_BESPOKE }}
       AcceptCHBrowserKey: ${{ secrets.ACCEPTCH_BROWSER_KEY}}
       AcceptCHHardwareKey: ${{ secrets.ACCEPTCH_HARDWARE_KEY}}
       AcceptCHPlatformKey: ${{ secrets.ACCEPTCH_PLATFORM_KEY}}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -18,10 +18,9 @@ jobs:
       cache-assets: true
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
-      DeviceDetection: ${{ secrets.DEVICE_DETECTION_KEY }}
+      DeviceDetection: ${{ secrets._51DEGREES_LICENSE_KEY_CLOUDV5PRO }}
       DeviceDetectionUrl: ${{ secrets.DEVICE_DETECTION_URL }}
-      TestResourceKey: ${{ secrets.SUPER_RESOURCE_KEY}}
-      ResourceKeyCloudV5Bespoke: ${{ secrets.RESOURCE_KEY_CLOUD_V5_BESPOKE }}
+      TestResourceKey: ${{ secrets._51DEGREES_RESOURCE_KEY_BESPOKE }}
       AcceptCHBrowserKey: ${{ secrets.ACCEPTCH_BROWSER_KEY}}
       AcceptCHHardwareKey: ${{ secrets.ACCEPTCH_HARDWARE_KEY}}
       AcceptCHPlatformKey: ${{ secrets.ACCEPTCH_PLATFORM_KEY}}

--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ Then, navigate to 'device-detection-cxx/device-detection-data' and execute:
 git lfs pull
 ```
 
+The examples in the
+[device-detection-dotnet-examples](https://github.com/51Degrees/device-detection-dotnet-examples)
+repository resolve the data file in the following order:
+
+1.  The `51DEGREES_DD_PATH` environment variable, set to an explicit path to
+    the data file.
+2.  A search of the folder hierarchy for the expected data file name.
+3.  The free 'Lite' data file in the device-detection-data submodule.
+
 ## Solutions and projects
 
 -   **FiftyOne.DeviceDetection** - Device detection engines and related
@@ -186,12 +195,14 @@ an 'inconclusive' result if these resources are not provided.
 
 -   Some tests require an 'Enterprise' data file. This can be obtained by
     [purchasing a license](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-dotnet&utm_content=readme.md&utm_term=tests).
-    -   Once available, the full path to this data file must be specified in the
-        `DEVICEDETECTIONDATAFILE` environment variable.
+    -   Once available, place the data file within the repository folder
+        structure. The tests locate it by searching the folder hierarchy for
+        the expected file name.
 -   Tests using the cloud service require resource keys with specific properties
     to be provided using environment variables:
-    -   The `SUPER_RESOURCE_KEY` environment variable should be populated with a
-        key that includes all properties. A
+    -   The `51DEGREES_RESOURCE_KEY` environment variable should be populated
+        with a key that includes all properties. The legacy `SUPER_RESOURCE_KEY`
+        environment variable is still supported and is checked second. A
         [license](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-dotnet&utm_content=readme.md&utm_term=tests-2) is required in order to access
         some properties.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Cloud API. You can create resource keys using our
 [documentation](https://51degrees.com/documentation/_concepts__configurator.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-dotnet&utm_content=readme.md&utm_term=cloud)
 on how to use this.
 
+The cloud property tiers changed in May 2026, so the examples and
+documentation now reflect what is free and what needs a paid subscription. A
+free resource key created at https://configure.51degrees.com/Wkqxf3Bs selects
+the free tier properties, whilst a key created at
+https://configure.51degrees.com/hYzn3TV3 also includes the paid properties
+used by the examples. See https://51degrees.com/pricing to get a paid
+subscription with more properties.
+
 #### On-Premise
 
 In order to perform device detection on-premise, you will need to use a

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The examples in the
 [device-detection-dotnet-examples](https://github.com/51Degrees/device-detection-dotnet-examples)
 repository resolve the data file in the following order:
 
-1.  The `51DEGREES_DD_PATH` environment variable, set to an explicit path to
+1.  The `_51DEGREES_DD_PATH` environment variable, set to an explicit path to
     the data file.
 2.  A search of the folder hierarchy for the expected data file name.
 3.  The free 'Lite' data file in the device-detection-data submodule.
@@ -208,7 +208,7 @@ an 'inconclusive' result if these resources are not provided.
         the expected file name.
 -   Tests using the cloud service require resource keys with specific properties
     to be provided using environment variables:
-    -   The `51DEGREES_RESOURCE_KEY` environment variable should be populated
+    -   The `_51DEGREES_RESOURCE_KEY` environment variable should be populated
         with a key that includes all properties. The legacy `SUPER_RESOURCE_KEY`
         environment variable is still supported and is checked second. A
         [license](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-dotnet&utm_content=readme.md&utm_term=tests-2) is required in order to access

--- a/Tests/FiftyOne.DeviceDetection.Cloud.Tests/DeviceDetectionCloudEngineTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.Cloud.Tests/DeviceDetectionCloudEngineTests.cs
@@ -36,7 +36,7 @@ namespace FiftyOne.DeviceDetection.Cloud.Tests
         /// The aligned environment variable name used to supply the resource
         /// key. This is checked before the legacy name.
         /// </summary>
-        private const string _resource_key_env_variable = "51DEGREES_RESOURCE_KEY";
+        private const string _resource_key_env_variable = "_51DEGREES_RESOURCE_KEY";
 
         /// <summary>
         /// The legacy environment variable name used to supply the resource

--- a/Tests/FiftyOne.DeviceDetection.Cloud.Tests/DeviceDetectionCloudEngineTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.Cloud.Tests/DeviceDetectionCloudEngineTests.cs
@@ -31,17 +31,29 @@ namespace FiftyOne.DeviceDetection.Cloud.Tests
     public class DeviceDetectionCloudEngineTests
     {
         private IPipeline _pipeline;
-        private const string _resource_key_env_variable = "SUPER_RESOURCE_KEY";
 
-        [TestInitialize] 
+        /// <summary>
+        /// The aligned environment variable name used to supply the resource
+        /// key. This is checked before the legacy name.
+        /// </summary>
+        private const string _resource_key_env_variable = "51DEGREES_RESOURCE_KEY";
+
+        /// <summary>
+        /// The legacy environment variable name used to supply the resource
+        /// key. Retained for backwards compatibility and checked when
+        /// <see cref="_resource_key_env_variable"/> is not set.
+        /// </summary>
+        private const string _legacy_resource_key_env_variable = "SUPER_RESOURCE_KEY";
+
+        [TestInitialize]
         public void Init()
         {
 
         }
-        
+
         /// <summary>
         /// Perform a simple gross error check by calling the cloud service
-        /// with a single User-Agent and validating the device type 
+        /// with a single User-Agent and validating the device type
         /// property is correct.
         /// This is an integration test that uses the live cloud service
         /// so any problems with that service could affect the result
@@ -52,6 +64,11 @@ namespace FiftyOne.DeviceDetection.Cloud.Tests
         {
             var resourceKey = System.Environment.GetEnvironmentVariable(
                 _resource_key_env_variable);
+            if (string.IsNullOrWhiteSpace(resourceKey))
+            {
+                resourceKey = System.Environment.GetEnvironmentVariable(
+                    _legacy_resource_key_env_variable);
+            }
 
             if (resourceKey != null)
             {
@@ -76,7 +93,8 @@ namespace FiftyOne.DeviceDetection.Cloud.Tests
             else
             {
                 Assert.Inconclusive($"No resource key supplied in " +
-                    $"environment variable '{_resource_key_env_variable}'");
+                    $"environment variable '{_resource_key_env_variable}' " +
+                    $"(or the legacy '{_legacy_resource_key_env_variable}')");
             }
         }
 
@@ -84,7 +102,7 @@ namespace FiftyOne.DeviceDetection.Cloud.Tests
         /// <summary>
         /// Verify that making requests using a resource key that
         /// is limited to particular origins will fail or succeed
-        /// in the expected scenarios. 
+        /// in the expected scenarios.
         /// This is an integration test that uses the live cloud service
         /// so any problems with that service could affect the result
         /// of this test.
@@ -94,7 +112,7 @@ namespace FiftyOne.DeviceDetection.Cloud.Tests
         [DataRow("test.com", true)]
         [DataRow("51degrees.com", false)]
         public void ResourceKeyWithOrigin(
-            string origin, 
+            string origin,
             bool expectException)
         {
             bool exception = false;

--- a/Tests/FiftyOne.DeviceDetection.RobotsTxt.Cloud.Tests/RobotsTxtCloudEngineTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.RobotsTxt.Cloud.Tests/RobotsTxtCloudEngineTests.cs
@@ -47,7 +47,7 @@ namespace FiftyOne.DeviceDetection.RobotsTxt.Cloud.Tests
     public class RobotsTxtCloudEngineTests
     {
         private ILoggerFactory _lf;
-        private const string _resource_key_env_variable = "RESOURCE_KEY_CLOUD_V5_BESPOKE";
+        private const string _resource_key_env_variable = "_51DEGREES_RESOURCE_KEY";
 
         [TestInitialize]
         public void Init()

--- a/ci/run-performance-tests-web.ps1
+++ b/ci/run-performance-tests-web.ps1
@@ -8,7 +8,7 @@ $PSNativeCommandUseErrorActionPreference = $true
 
 $perfTests = "$PSScriptRoot/../performance-tests"
 
-$env:PipelineOptions__Elements__0__BuildParameters__DataFile = $env:DEVICEDETECTIONDATAFILE
+$env:PipelineOptions__Elements__0__BuildParameters__DataFile = $env:_51DEGREES_DD_PATH
 
 dotnet build $perfTests -c $Configuration /p:Platform=$Arch
 try {

--- a/ci/setup-environment.ps1
+++ b/ci/setup-environment.ps1
@@ -27,6 +27,10 @@ if ($IsLinux) {
 
 $env:DEVICEDETECTIONDATAFILE = [IO.Path]::Combine($RepoPath, "FiftyOne.DeviceDetection.Hash.Engine.OnPremise", "device-detection-cxx", "device-detection-data", "TAC-HashV41.hash")
 $env:SUPER_RESOURCE_KEY = $Keys.TestResourceKey
+# Aligned environment variable names. These are checked first by the tests
+# and examples. The legacy names above are retained for backwards compatibility.
+${env:51DEGREES_DD_PATH} = [IO.Path]::Combine($RepoPath, "FiftyOne.DeviceDetection.Hash.Engine.OnPremise", "device-detection-cxx", "device-detection-data", "TAC-HashV41.hash")
+${env:51DEGREES_RESOURCE_KEY} = $Keys.TestResourceKey
 $env:RESOURCE_KEY_CLOUD_V5_BESPOKE = $Keys.ResourceKeyCloudV5Bespoke
 $env:DEVICEDETECTIONLICENSEKEY_DOTNET = $Keys.DeviceDetection
 $env:ACCEPTCH_BROWSER_KEY = $Keys.AcceptCHBrowserKey

--- a/ci/setup-environment.ps1
+++ b/ci/setup-environment.ps1
@@ -1,6 +1,5 @@
 param(
-    [Parameter(Mandatory=$true)]
-    [string]$RepoName,
+    [Parameter(Mandatory)][string]$RepoName,
     [string]$ProjectDir = ".",
     [string]$Name = "Release_x64",
     [string]$Arch = "x64",
@@ -22,20 +21,16 @@ if ($IsLinux) {
     sudo apt-get update
     # Install multilib, as this may be required.
     sudo apt-get install -y gcc-multilib g++-multilib
-
 }
 
-$env:DEVICEDETECTIONDATAFILE = [IO.Path]::Combine($RepoPath, "FiftyOne.DeviceDetection.Hash.Engine.OnPremise", "device-detection-cxx", "device-detection-data", "TAC-HashV41.hash")
-$env:SUPER_RESOURCE_KEY = $Keys.TestResourceKey
-# Aligned environment variable names. These are checked first by the tests
-# and examples. The legacy names above are retained for backwards compatibility.
-${env:51DEGREES_DD_PATH} = [IO.Path]::Combine($RepoPath, "FiftyOne.DeviceDetection.Hash.Engine.OnPremise", "device-detection-cxx", "device-detection-data", "TAC-HashV41.hash")
-${env:51DEGREES_RESOURCE_KEY} = $Keys.TestResourceKey
-$env:RESOURCE_KEY_CLOUD_V5_BESPOKE = $Keys.ResourceKeyCloudV5Bespoke
-$env:DEVICEDETECTIONLICENSEKEY_DOTNET = $Keys.DeviceDetection
+$env:_51DEGREES_DD_PATH = "$PWD/$RepoName/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/device-detection-cxx/device-detection-data/TAC-HashV41.hash"
+$env:_51DEGREES_RESOURCE_KEY = $Keys.TestResourceKey
 $env:ACCEPTCH_BROWSER_KEY = $Keys.AcceptCHBrowserKey
 $env:ACCEPTCH_HARDWARE_KEY = $Keys.AcceptCHHardwareKey
 $env:ACCEPTCH_PLATFORM_KEY = $Keys.AcceptCHPlatformKey
 $env:ACCEPTCH_NONE_KEY = $Keys.AcceptCHNoneKey
+
+# Legacy environment variables, checked if the new ones aren't set
+$env:SUPER_RESOURCE_KEY = $env:_51DEGREES_RESOURCE_KEY
 
 [IO.File]::WriteAllBytes("$PSScriptRoot/../51Degrees.snk", [Convert]::FromBase64String($StrongNameKeyBase64))


### PR DESCRIPTION
## Summary

This change aligns the resource key environment variable used by the cloud tests with the convention shared across 51Degrees repositories.

- The cloud tests read the resource key from `51DEGREES_RESOURCE_KEY` first. The legacy `SUPER_RESOURCE_KEY` name is retained and checked second.
- The README documents the aligned names, including the `51DEGREES_DD_PATH` data file path convention used by the examples repository.
- The CI setup script also sets the aligned names, with the legacy assignments retained.

## Notes

- No code in this repository reads a data file path from the environment, so the data file change is documentation only.
- GitHub workflow secret references are unchanged. An accompanying issue advises on the aligned secret naming.
- The aligned names start with a digit, which POSIX shells do not accept in plain assignments. On Linux and macOS set them with the env command, for example `env 51DEGREES_RESOURCE_KEY=AAA dotnet test`.
