### PR TITLE
TEST: Enforce MSTest analyzers and centralize test config so we can remove warning suppression properly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,34 @@ When new projects are added, be sure to update the `.slnf` file too.
 This is a solution filter which loads only dotnet core projects, and
 can be used to build on platforms like Linux which do not have support
 for Framework.
+
+## Building locally
+
+`FiftyOne.DeviceDetection.Hash.Engine.OnPremise` has a native C++ core that is
+compiled by CMake during the build (`PreBuild.ps1`). CMake must be able to target
+the installed Visual Studio toolchain. If a system-wide CMake that predates your
+Visual Studio version is first on `PATH`, the configure step fails with
+`CMAKE_CXX_COMPILER not set` or a generator mismatch
+(`Does not match the generator used previously`).
+
+Use the CMake bundled with Visual Studio (it always matches the installed VS
+generator) by putting it first on `PATH`, e.g. for VS 2022/18 on Windows:
+
+```powershell
+$env:PATH = "C:\Program Files\Microsoft Visual Studio\18\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin;$env:PATH"
+dotnet build -p:Platform=x64
+```
+
+If you hit the generator-mismatch error after switching CMake versions, delete the
+stale native build dir and rebuild:
+`FiftyOne.DeviceDetection.Hash.Engine.OnPremise/build/`.
+
+### Test projects
+
+Shared test configuration (the `Microsoft.NET.Test.Sdk`, `Moq` and `MSTest`
+package references) lives in `Tests/Directory.Build.props` and is applied to any
+project under `Tests/` that sets `<IsTestProject>true</IsTestProject>`. The
+non-test projects in that folder (`TestHelpers`, `Tests.Framework`,
+`PackageConsumption`) deliberately do not set it. MSTest's analyzers are enabled
+via the `MSTest` meta-package; their rules are build-breaking under
+`TreatWarningsAsErrors`, so new test code must follow the MSTest analyzer patterns.

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -1,0 +1,16 @@
+<Project>
+
+  <!-- Link to the repository root Directory.Build.props.
+       MSBuild onlyauto-imports the nearest Directory.Build.props, so the root 
+       one must be imported explicitly. -->
+  <Import Project="$(MSBuildThisFileDirectory)..\Directory.Build.props" />
+
+  <!-- Shared test-harness packages for the MSTest unit-test projects under Tests/.
+       Each unit-test project opts in with <IsTestProject>true</IsTestProject>. -->
+  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="MSTest" Version="4.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/FiftyOne.DeviceDetection.Cloud.Tests/FiftyOne.DeviceDetection.Cloud.Tests.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Cloud.Tests/FiftyOne.DeviceDetection.Cloud.Tests.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
+		<IsTestProject>true</IsTestProject>
 		<IsPackable>false</IsPackable>
 		<Platforms>AnyCPU;x64;x86;ARM64</Platforms>
 		<Configurations>Debug;Release</Configurations>
@@ -17,9 +18,6 @@
 		<PackageReference Include="FiftyOne.Pipeline.Engines.TestHelpers" Version="4.5.57" />
 		<PackageReference Include="FiftyOne.Pipeline.Web" Version="4.5.57" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/FiftyOne.DeviceDetection.Hash.Tests/FiftyOne.DeviceDetection.Hash.Tests.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Hash.Tests/FiftyOne.DeviceDetection.Hash.Tests.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
 		<Platforms>x86;x64;ARM64;AnyCPU</Platforms>
 		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0;net462</TargetFrameworks>
 		<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net8.0</TargetFrameworks>
@@ -18,9 +19,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
 		<PackageReference Include="System.Text.Json" Version="8.0.6" />
 	</ItemGroup>
 

--- a/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests.csproj
+++ b/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests.csproj
@@ -2,20 +2,22 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <Platforms>x86;x64;ARM64;AnyCPU</Platforms>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+    <ProjectReference Include="..\..\FiftyOne.DeviceDetection.PropertyKeyed\FiftyOne.DeviceDetection.PropertyKeyed.csproj" />
+    <ProjectReference Include="..\FiftyOne.DeviceDetection.TestHelpers\FiftyOne.DeviceDetection.TestHelpers.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\FiftyOne.DeviceDetection.PropertyKeyed\FiftyOne.DeviceDetection.PropertyKeyed.csproj" />
-    <ProjectReference Include="..\FiftyOne.DeviceDetection.TestHelpers\FiftyOne.DeviceDetection.TestHelpers.csproj" />
+    <AssemblyAttribute Include="Microsoft.VisualStudio.TestTools.UnitTesting.Parallelize">
+      <_Parameter1>Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.ClassLevel</_Parameter1>
+      <_Parameter1_IsLiteral>true</_Parameter1_IsLiteral>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>

--- a/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/TacKeyedEngineTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/TacKeyedEngineTests.cs
@@ -26,8 +26,6 @@ using FiftyOne.Pipeline.Core.Exceptions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 
-[assembly: Parallelize(Scope = ExecutionScope.ClassLevel)]
-
 namespace FiftyOne.DeviceDetection.PropertyKeyed.Tests
 {
     /// <summary>

--- a/Tests/FiftyOne.DeviceDetection.RobotsTxt.Cloud.Tests/FiftyOne.DeviceDetection.RobotsTxt.Cloud.Tests.csproj
+++ b/Tests/FiftyOne.DeviceDetection.RobotsTxt.Cloud.Tests/FiftyOne.DeviceDetection.RobotsTxt.Cloud.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <Platforms>AnyCPU;x64;x86;ARM64</Platforms>
     <Configurations>Debug;Release</Configurations>
@@ -16,9 +17,6 @@
     <PackageReference Include="FiftyOne.Common.TestHelpers" Version="5.1.8" />
     <PackageReference Include="FiftyOne.Pipeline.Engines.TestHelpers" Version="4.5.57" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests.csproj
+++ b/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests.csproj
@@ -2,20 +2,22 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <Platforms>x86;x64;ARM64;AnyCPU</Platforms>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+    <ProjectReference Include="..\..\FiftyOne.DeviceDetection.RobotsTxt\FiftyOne.DeviceDetection.RobotsTxt.csproj" />
+    <ProjectReference Include="..\FiftyOne.DeviceDetection.TestHelpers\FiftyOne.DeviceDetection.TestHelpers.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\FiftyOne.DeviceDetection.RobotsTxt\FiftyOne.DeviceDetection.RobotsTxt.csproj" />
-    <ProjectReference Include="..\FiftyOne.DeviceDetection.TestHelpers\FiftyOne.DeviceDetection.TestHelpers.csproj" />
+    <AssemblyAttribute Include="Microsoft.VisualStudio.TestTools.UnitTesting.Parallelize">
+      <_Parameter1>Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.ClassLevel</_Parameter1>
+      <_Parameter1_IsLiteral>true</_Parameter1_IsLiteral>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>

--- a/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/RobotsTxtTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.RobotsTxt.Tests/RobotsTxtTests.cs
@@ -32,8 +32,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
-[assembly: Parallelize(Scope = ExecutionScope.ClassLevel)]
-
 namespace FiftyOne.DeviceDetection.RobotsTxt.Tests
 {
     /// <summary>

--- a/Tests/FiftyOne.DeviceDetection.Tests.Core/FiftyOne.DeviceDetection.Tests.Core.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Tests.Core/FiftyOne.DeviceDetection.Tests.Core.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
+		<IsTestProject>true</IsTestProject>
 		<IsPackable>false</IsPackable>
 		<Platforms>AnyCPU;x86;x64;ARM64</Platforms>
 		<Configurations>Debug;Release</Configurations>
@@ -9,9 +10,6 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Changes 
- The test projects referenced only MSTest.TestAdapter, which pulls
MSTest.TestFramework but not MSTest.Analyzers, so the MSTest 4.0 analyzer
rules never ran. Activate them through the MSTest meta-package so they
are enforced at build time.

- Add Tests/Directory.Build.props that imports the root props (keeping
assembly signing) and supplies the shared test harness packages
(Microsoft.NET.Test.Sdk, Moq, MSTest) to any project under Tests that
sets IsTestProject. The non-test projects in that folder (TestHelpers,
Tests.Framework, PackageConsumption) do not set it and are left alone.

- Slim the six unit test projects to drop the now centralized package
references and add the IsTestProject flag.

- Standardize the Parallelize assembly attribute on the csproj convention.
PropertyKeyed.Tests and RobotsTxt.Tests move their C# assembly attribute
into the csproj at their existing ClassLevel scope. The four MethodLevel
projects are unchanged. Each test assembly declares exactly one attribute.

- Document in CONTRIBUTING.md the new test config convention.

## Notes 

Because TreatWarningsAsErrors is enabled, these analyzer rules are now
build-breaking. The existing test code already conforms, so the full
solution builds clean and all tests pass.
