### PR TITLE
Optimize on-premise property reads: cache availability 

### DIFF
--- a/FiftyOne.DeviceDetection.Data/Data/DeviceDataBaseOnPremise.cs
+++ b/FiftyOne.DeviceDetection.Data/Data/DeviceDataBaseOnPremise.cs
@@ -34,6 +34,22 @@ using System.Collections.Generic;
 namespace FiftyOne.DeviceDetection.Shared.Data
 {
     /// <summary>
+    /// Resolves, once per closed generic type <typeparamref name="T"/>, the inner
+    /// value type that <typeparamref name="T"/> wraps
+    /// (e.g. <c>IAspectPropertyValue&lt;bool&gt;</c> -&gt; <c>bool</c>). The result
+    /// is stored in a per-<typeparamref name="T"/> static field, so typed property
+    /// getters avoid both a per-read dictionary lookup and the array allocation of
+    /// <see cref="Type.GenericTypeArguments"/>. A <see langword="null"/> value means
+    /// <typeparamref name="T"/> is <see cref="object"/> (untyped access) and the
+    /// inner type must instead be resolved from the property name.
+    /// </summary>
+    internal static class InnerTypeCache<T>
+    {
+        public static readonly Type Value =
+            typeof(T) == typeof(object) ? null : typeof(T).GenericTypeArguments[0];
+    }
+
+    /// <summary>
     /// Base class used for all 51Degrees on-premise device data.
     /// See the <see href="https://github.com/51Degrees/specifications/blob/main/device-detection-specification/data-model.md">Specification</see>
     /// </summary>
@@ -405,21 +421,18 @@ namespace FiftyOne.DeviceDetection.Shared.Data
         private static ConcurrentDictionary<string, Type> _innerTypes = new ConcurrentDictionary<string, Type>();
         private Type GetInnerType<T>(string propertyName)
         {
-            return _innerTypes.GetOrAdd(propertyName,
-                (string key) =>
-                {
-                    Type type = typeof(T);
-                    Type innerType;
-                    if (type == typeof(object))
-                    {
-                        innerType = GetPropertyType(key);
-                    }
-                    else
-                    {
-                        innerType = type.GenericTypeArguments[0];
-                    }
-                    return innerType;
-                });
+            // For a concrete requested type (e.g. IAspectPropertyValue<bool>) the
+            // inner value type depends only on T, so it is resolved once per closed
+            // generic T (see InnerTypeCache) - no per-read dictionary lookup and no
+            // GenericTypeArguments array allocation. Only untyped access
+            // (T == object, via the string indexer) needs the property name, and
+            // that path keeps the original name-keyed cache.
+            Type inner = InnerTypeCache<T>.Value;
+            if (inner != null)
+            {
+                return inner;
+            }
+            return _innerTypes.GetOrAdd(propertyName, key => GetPropertyType(key));
         }
 
         /// <summary>

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/Data/DeviceDataHash.cs
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/Data/DeviceDataHash.cs
@@ -43,6 +43,7 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Data
     internal class DeviceDataHash : DeviceDataBaseOnPremise<IResultsSwigWrapper>, IDeviceDataHash, IDisposable
     {
         private bool disposedValue;
+        private readonly DeviceDetectionHashEngine _engine;
         private static ThreadLocal<ResultsHashSerializer> resultsHashSerializer = new ThreadLocal<ResultsHashSerializer>(() => (
             new ResultsHashSerializer()
         ));
@@ -71,6 +72,7 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Data
             IMissingPropertyService missingPropertyService)
             : base(logger, pipeline, engine, missingPropertyService)
         {
+            _engine = engine;
         }
 
         #endregion
@@ -266,8 +268,21 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Data
         protected override bool PropertyIsAvailable(string propertyName)
         {
             CheckState();
-            return Results.ResultsList
+            // Whether a property is present in the results is constant for the
+            // lifetime of a loaded data file, so memoise it on the engine to
+            // avoid a native containsProperty P/Invoke on every property read
+            // (issue #524 result-access hot path). The first read of each
+            // property still resolves via the native call below; subsequent
+            // reads - across all detections - are served from the cache.
+            if (_engine.PropertyAvailableCache.TryGetValue(
+                propertyName, out bool available))
+            {
+                return available;
+            }
+            available = Results.ResultsList
                 .Any(r => r.containsProperty(propertyName));
+            _engine.PropertyAvailableCache[propertyName] = available;
+            return available;
         }
 
         protected override IAspectPropertyValue<bool> GetValueAsBool(string propertyName)

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/FlowElements/DeviceDetectionHashEngine.cs
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/FlowElements/DeviceDetectionHashEngine.cs
@@ -53,10 +53,24 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.FlowElements
         private IEngineSwigWrapper _engine;
 
         /// <summary>
-        /// Evidence key filter for the engine. Set in 
+        /// Evidence key filter for the engine. Set in
         /// <see cref="InitEngineMetaData"/> after refresh.
         /// </summary>
         private IEvidenceKeyFilter _evidenceKeyFilter;
+
+        /// <summary>
+        /// Caches, per property name, whether that property is present in the
+        /// native results (i.e. the answer to <c>ResultsHash.containsProperty</c>).
+        /// This answer is constant for the lifetime of a loaded data file, so it
+        /// is memoised here to avoid a native P/Invoke on every property read.
+        /// Cleared in <see cref="InitEngineMetaData"/> whenever the data file is
+        /// refreshed. Keyed ordinally so each distinct casing keeps the exact
+        /// answer the native call would give it.
+        /// </summary>
+        internal readonly System.Collections.Concurrent.ConcurrentDictionary<string, bool>
+            PropertyAvailableCache =
+                new System.Collections.Concurrent.ConcurrentDictionary<string, bool>(
+                    StringComparer.Ordinal);
 
         /// <summary>
         /// Properties for the engine. Set in <see cref="InitEngineMetaData"/> 
@@ -392,6 +406,10 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.FlowElements
         /// </summary>
         private void InitEngineMetaData()
         {
+            // The set of properties present in the results can change when a new
+            // data file is loaded, so drop the memoised availability answers.
+            PropertyAvailableCache.Clear();
+
             _evidenceKeyFilter = new EvidenceKeyFilterWhitelist(
                 new List<string>(_engine.getKeys()),
                 StringComparer.InvariantCultureIgnoreCase);


### PR DESCRIPTION
+ resolve inner type per-T

Two allocation/P-Invoke reductions on the hash engine property-read path (issue #524), both managed-only with no native or SWIG changes:

- Memoize property availability. PropertyIsAvailable ran a native containsProperty P/Invoke on every property read; availability is constant for a loaded data file, so cache it per engine (cleared on data refresh) and serve subsequent reads from a managed dictionary.

- Resolve the wrapped value type once per closed generic T. GetInnerType used a name-keyed ConcurrentDictionary whose GetOrAdd factory captured `this`, allocating a closure on every read; typed getters now resolve the inner type from a per-T static (InnerTypeCache<T>), avoiding both the dictionary lookup and the closure. The untyped indexer path is unchanged.

Behaviour is unchanged (metric-property fall-through preserved; full Hash.Tests suite green). Measured on the read path: ~18% faster with the availability cache; ~26% fewer allocations per typed read with the inner-type change.