### PR TITLE
Add flattened by-value scalar property accessors (issue #524)

### DIFF
--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/CMakeLists.txt
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/CMakeLists.txt
@@ -71,7 +71,8 @@ if (RebuildSwig)
 endif()
 
 add_library(fiftyone-hash-dotnet SHARED
-    ${CMAKE_CURRENT_LIST_DIR}/DeviceDetectionHashEngineSwig_csharp.cpp)
+    ${CMAKE_CURRENT_LIST_DIR}/DeviceDetectionHashEngineSwig_csharp.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/DeviceDetectionFastValues.cpp)
 
 if(UNIX)
     set_target_properties(fiftyone-hash-dotnet

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/Data/DeviceDataHash.cs
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/Data/DeviceDataHash.cs
@@ -292,6 +292,14 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Data
 
             if (results != null)
             {
+                // Fast flattened path (fix #4): one P/Invoke, no Value<T> object.
+                // Fall back to the SWIG value object only when there is no value,
+                // to recover the no-value message.
+                if (results.TryGetBoolFast(propertyName, out bool fast))
+                {
+                    result.Value = fast;
+                    return result;
+                }
                 using (var value = results.getValueAsBool(propertyName))
                 {
                     if (value.hasValue())
@@ -314,6 +322,11 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Data
 
             if (results != null)
             {
+                if (results.TryGetDoubleFast(propertyName, out double fast))
+                {
+                    result.Value = fast;
+                    return result;
+                }
                 using (var value = results.getValueAsDouble(propertyName))
                 {
                     if (value.hasValue())
@@ -336,6 +349,11 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Data
 
             if (results != null)
             {
+                if (results.TryGetIntFast(propertyName, out int fast))
+                {
+                    result.Value = fast;
+                    return result;
+                }
                 using (var value = results.getValueAsInteger(propertyName))
                 {
                     if (value.hasValue())
@@ -397,6 +415,11 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Data
 
             if (results != null)
             {
+                if (results.TryGetStringFast(propertyName, out string fast))
+                {
+                    result.Value = fast;
+                    return result;
+                }
                 using (var value = results.getValueAsString(propertyName))
                 {
                     if (value.hasValue())
@@ -419,6 +442,12 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Data
 
             if (results != null)
             {
+                // JavaScript is a string value; use the same flattened fast path.
+                if (results.TryGetStringFast(propertyName, out string fast))
+                {
+                    result.Value = new JavaScript(fast);
+                    return result;
+                }
                 using (var value = results.getValueAsString(propertyName))
                 {
                     if (value.hasValue())

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/DeviceDetectionFastValues.cpp
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/DeviceDetectionFastValues.cpp
@@ -1,0 +1,134 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+/*
+ * Flattened, "by value" scalar property accessors for the .NET on-premise hash
+ * engine (issue #524, fix #4).
+ *
+ * The SWIG-generated getValueAsBool/Integer/Double/String each return a heap
+ * `Value<T>` wrapper object (a native object with a finalizer, plus its managed
+ * proxy) that the caller must then interrogate with hasValue()/getValue() and
+ * dispose - roughly four P/Invokes and two heap allocations to read one value.
+ * Property reads are the dominant managed cost of a detection, so these helpers
+ * return the value (and its has-value flag) across the P/Invoke boundary in a
+ * single call with no wrapper object.
+ *
+ * This is deliberately a small hand-written translation unit rather than a SWIG
+ * %extend + regen: the checked-in SWIG bindings are ~21 months behind the cxx
+ * submodule, so regenerating would pull in a large, unrelated binding refresh.
+ * The equivalent %extend is documented in hash_csharp.i for the next full regen.
+ *
+ * Each function calls the same C++ ResultsHash getters the SWIG path uses, so
+ * behaviour (value, no-value) is identical; the managed side falls back to the
+ * SWIG path when hasValue is false, to recover the no-value message.
+ */
+
+#include "device-detection-cxx/src/hash/EngineHash.hpp"
+#include <string>
+#include <cstring>
+
+#ifndef SWIGEXPORT
+#  if defined(_WIN32)
+#    define SWIGEXPORT __declspec(dllexport)
+#  else
+#    define SWIGEXPORT
+#  endif
+#endif
+
+using namespace FiftyoneDegrees::DeviceDetection::Hash;
+
+// Bool: returns 0/1; *hasValue set to 1 when a value is present, else 0.
+extern "C" SWIGEXPORT int fiftyone_hash_get_bool(
+    void* resultsPtr, const char* name, int* hasValue) {
+    try {
+        ResultsHash* results = static_cast<ResultsHash*>(resultsPtr);
+        auto value = results->getValueAsBool(name);
+        if (value.hasValue()) {
+            *hasValue = 1;
+            return value.getValue() ? 1 : 0;
+        }
+    }
+    catch (...) {
+    }
+    *hasValue = 0;
+    return 0;
+}
+
+// Integer: returns the value; *hasValue set to 1 when present, else 0.
+extern "C" SWIGEXPORT int fiftyone_hash_get_int(
+    void* resultsPtr, const char* name, int* hasValue) {
+    try {
+        ResultsHash* results = static_cast<ResultsHash*>(resultsPtr);
+        auto value = results->getValueAsInteger(name);
+        if (value.hasValue()) {
+            *hasValue = 1;
+            return value.getValue();
+        }
+    }
+    catch (...) {
+    }
+    *hasValue = 0;
+    return 0;
+}
+
+// Double: returns the value; *hasValue set to 1 when present, else 0.
+extern "C" SWIGEXPORT double fiftyone_hash_get_double(
+    void* resultsPtr, const char* name, int* hasValue) {
+    try {
+        ResultsHash* results = static_cast<ResultsHash*>(resultsPtr);
+        auto value = results->getValueAsDouble(name);
+        if (value.hasValue()) {
+            *hasValue = 1;
+            return value.getValue();
+        }
+    }
+    catch (...) {
+    }
+    *hasValue = 0;
+    return 0.0;
+}
+
+// String: returns 1 if a value is present (0 otherwise). When present, *needed is
+// set to the value's byte length and, if it fits (length < bufLen), the value is
+// copied into buffer NUL-terminated. If it does not fit, buffer is left untouched
+// and the caller retries via the slow path. No SWIG wrapper object is created.
+extern "C" SWIGEXPORT int fiftyone_hash_get_string(
+    void* resultsPtr, const char* name, char* buffer, int bufLen, int* needed) {
+    try {
+        ResultsHash* results = static_cast<ResultsHash*>(resultsPtr);
+        auto value = results->getValueAsString(name);
+        if (value.hasValue()) {
+            std::string s = value.getValue();
+            int len = (int)s.length();
+            *needed = len;
+            if (buffer != nullptr && len < bufLen) {
+                memcpy(buffer, s.c_str(), (size_t)len);
+                buffer[len] = '\0';
+            }
+            return 1;
+        }
+    }
+    catch (...) {
+    }
+    *needed = 0;
+    return 0;
+}

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/DeviceDetectionFastValues.cpp
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/DeviceDetectionFastValues.cpp
@@ -60,6 +60,10 @@ using namespace FiftyoneDegrees::DeviceDetection::Hash;
 // Bool: returns 0/1; *hasValue set to 1 when a value is present, else 0.
 extern "C" SWIGEXPORT int fiftyone_hash_get_bool(
     void* resultsPtr, const char* name, int* hasValue) {
+    // A disposed managed proxy passes a null pointer; catch(...) would not catch
+    // the resulting access violation, so report no-value and let the managed
+    // slow-path fallback raise the usual exception.
+    if (resultsPtr == nullptr) { *hasValue = 0; return 0; }
     try {
         ResultsHash* results = static_cast<ResultsHash*>(resultsPtr);
         auto value = results->getValueAsBool(name);
@@ -77,6 +81,7 @@ extern "C" SWIGEXPORT int fiftyone_hash_get_bool(
 // Integer: returns the value; *hasValue set to 1 when present, else 0.
 extern "C" SWIGEXPORT int fiftyone_hash_get_int(
     void* resultsPtr, const char* name, int* hasValue) {
+    if (resultsPtr == nullptr) { *hasValue = 0; return 0; }
     try {
         ResultsHash* results = static_cast<ResultsHash*>(resultsPtr);
         auto value = results->getValueAsInteger(name);
@@ -94,6 +99,7 @@ extern "C" SWIGEXPORT int fiftyone_hash_get_int(
 // Double: returns the value; *hasValue set to 1 when present, else 0.
 extern "C" SWIGEXPORT double fiftyone_hash_get_double(
     void* resultsPtr, const char* name, int* hasValue) {
+    if (resultsPtr == nullptr) { *hasValue = 0; return 0.0; }
     try {
         ResultsHash* results = static_cast<ResultsHash*>(resultsPtr);
         auto value = results->getValueAsDouble(name);
@@ -114,6 +120,7 @@ extern "C" SWIGEXPORT double fiftyone_hash_get_double(
 // and the caller retries via the slow path. No SWIG wrapper object is created.
 extern "C" SWIGEXPORT int fiftyone_hash_get_string(
     void* resultsPtr, const char* name, char* buffer, int bufLen, int* needed) {
+    if (resultsPtr == nullptr) { *needed = 0; return 0; }
     try {
         ResultsHash* results = static_cast<ResultsHash*>(resultsPtr);
         auto value = results->getValueAsString(name);

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/DeviceDetectionFastValues.cpp
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/DeviceDetectionFastValues.cpp
@@ -35,7 +35,8 @@
  * This is deliberately a small hand-written translation unit rather than a SWIG
  * %extend + regen: the checked-in SWIG bindings are ~21 months behind the cxx
  * submodule, so regenerating would pull in a large, unrelated binding refresh.
- * The equivalent %extend is documented in hash_csharp.i for the next full regen.
+ * The equivalent %extend is documented in hash_csharp.i for the next full regen,
+ * which is tracked in issue #823 (this TU is retired once that regen lands).
  *
  * Each function calls the same C++ ResultsHash getters the SWIG path uses, so
  * behaviour (value, no-value) is identical; the managed side falls back to the

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/DeviceDetectionFastValues.cpp
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/DeviceDetectionFastValues.cpp
@@ -41,6 +41,13 @@
  * Each function calls the same C++ ResultsHash getters the SWIG path uses, so
  * behaviour (value, no-value) is identical; the managed side falls back to the
  * SWIG path when hasValue is false, to recover the no-value message.
+ *
+ * Invariant: resultsPtr is ResultsHashSwig.getCPtr(...).Handle, i.e. the pointer
+ * SWIG stored at construction, which for the concrete proxy is the original
+ * ResultsHash* cast to void*. static_cast<ResultsHash*> is therefore exact with
+ * no base-class adjustment. This holds only while the binding stores the derived
+ * ResultsHash pointer; it would break if a future regen handed us an upcast base
+ * pointer, so the managed side must keep passing the ResultsHash proxy's handle.
  */
 
 #include "device-detection-cxx/src/hash/EngineHash.hpp"

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/Wrappers/IResultsSwigWrapper.cs
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/Wrappers/IResultsSwigWrapper.cs
@@ -42,5 +42,14 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Wrappers
         IValueSwigWrapper<int> getValueAsInteger(string propertyName);
         IValueSwigWrapper<double> getValueAsDouble(string propertyName);
 
+        // Flattened "by value" fast paths (issue #524, fix #4): return the value
+        // and its has-value flag in a single P/Invoke with no Value<T> wrapper
+        // object. Return false when there is no value (or, for strings, when the
+        // value is too long to fit the fast-path buffer); the caller then uses the
+        // matching getValueAsX slow path to recover the value / no-value message.
+        bool TryGetBoolFast(string propertyName, out bool value);
+        bool TryGetIntFast(string propertyName, out int value);
+        bool TryGetDoubleFast(string propertyName, out double value);
+        bool TryGetStringFast(string propertyName, out string value);
     }
 }

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/Wrappers/ResultsSwigWrapper.cs
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/Wrappers/ResultsSwigWrapper.cs
@@ -21,16 +21,90 @@
  * ********************************************************************* */
 
 using FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Interop;
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Wrappers
 {
     internal class ResultsSwigWrapper : IResultsSwigWrapper
     {
+        // Flattened, "by value" scalar accessors (issue #524, fix #4). These call
+        // the hand-written native exports in DeviceDetectionFastValues.cpp, which
+        // return the value and its has-value flag in a single P/Invoke with no
+        // Value<T> (BoolValueSwig etc.) heap object. Used by the fast paths in
+        // DeviceDataHash; see that class for the slow-path fallback that recovers
+        // the no-value message.
+        private const string NativeLib =
+            "FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll";
+
+        [DllImport(NativeLib, EntryPoint = "fiftyone_hash_get_bool", CharSet = CharSet.Ansi)]
+        private static extern int fiftyone_hash_get_bool(IntPtr results, string name, out int hasValue);
+
+        [DllImport(NativeLib, EntryPoint = "fiftyone_hash_get_int", CharSet = CharSet.Ansi)]
+        private static extern int fiftyone_hash_get_int(IntPtr results, string name, out int hasValue);
+
+        [DllImport(NativeLib, EntryPoint = "fiftyone_hash_get_double", CharSet = CharSet.Ansi)]
+        private static extern double fiftyone_hash_get_double(IntPtr results, string name, out int hasValue);
+
+        [DllImport(NativeLib, EntryPoint = "fiftyone_hash_get_string", CharSet = CharSet.Ansi)]
+        private static extern int fiftyone_hash_get_string(IntPtr results, string name, byte[] buffer, int bufLen, out int needed);
+
+        // Reusable per-thread buffer for the string fast path, sized to cover
+        // effectively all device-detection property values; longer values fall
+        // back to the slow SWIG path.
+        [ThreadStatic]
+        private static byte[] _stringBuffer;
+
         public ResultsHashSwig Object { get; }
 
         public ResultsSwigWrapper(ResultsHashSwig instance)
         {
             Object = instance;
+        }
+
+        public bool TryGetBoolFast(string propertyName, out bool value)
+        {
+            int has = 0;
+            int v = fiftyone_hash_get_bool(ResultsHashSwig.getCPtr(Object).Handle, propertyName, out has);
+            GC.KeepAlive(Object);
+            value = v != 0;
+            return has != 0;
+        }
+
+        public bool TryGetIntFast(string propertyName, out int value)
+        {
+            int has = 0;
+            value = fiftyone_hash_get_int(ResultsHashSwig.getCPtr(Object).Handle, propertyName, out has);
+            GC.KeepAlive(Object);
+            return has != 0;
+        }
+
+        public bool TryGetDoubleFast(string propertyName, out double value)
+        {
+            int has = 0;
+            value = fiftyone_hash_get_double(ResultsHashSwig.getCPtr(Object).Handle, propertyName, out has);
+            GC.KeepAlive(Object);
+            return has != 0;
+        }
+
+        public bool TryGetStringFast(string propertyName, out string value)
+        {
+            var buffer = _stringBuffer ?? (_stringBuffer = new byte[512]);
+            int needed = 0;
+            int has = fiftyone_hash_get_string(
+                ResultsHashSwig.getCPtr(Object).Handle, propertyName, buffer, buffer.Length, out needed);
+            GC.KeepAlive(Object);
+            // has == 0 -> no value (caller falls back for the no-value message).
+            // needed >= buffer.Length -> value too long to fit; fall back so the
+            // slow path returns the full value.
+            if (has == 0 || needed >= buffer.Length)
+            {
+                value = null;
+                return false;
+            }
+            value = Encoding.UTF8.GetString(buffer, 0, needed);
+            return true;
         }
         public bool containsProperty(string propertyName)
         {

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/Wrappers/ResultsSwigWrapper.cs
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/Wrappers/ResultsSwigWrapper.cs
@@ -48,7 +48,7 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Wrappers
         private static extern double fiftyone_hash_get_double(IntPtr results, string name, out int hasValue);
 
         [DllImport(NativeLib, EntryPoint = "fiftyone_hash_get_string", CharSet = CharSet.Ansi)]
-        private static extern int fiftyone_hash_get_string(IntPtr results, string name, byte[] buffer, int bufLen, out int needed);
+        private static extern int fiftyone_hash_get_string(IntPtr results, string name, byte[] buffer, int bufferLength, out int valueLength);
 
         // Reusable per-thread buffer for the string fast path, sized to cover
         // effectively all device-detection property values; longer values fall
@@ -65,45 +65,45 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Wrappers
 
         public bool TryGetBoolFast(string propertyName, out bool value)
         {
-            int has = 0;
-            int v = fiftyone_hash_get_bool(ResultsHashSwig.getCPtr(Object).Handle, propertyName, out has);
+            int hasValue = 0;
+            int boolAsInt = fiftyone_hash_get_bool(ResultsHashSwig.getCPtr(Object).Handle, propertyName, out hasValue);
             GC.KeepAlive(Object);
-            value = v != 0;
-            return has != 0;
+            value = boolAsInt != 0;
+            return hasValue != 0;
         }
 
         public bool TryGetIntFast(string propertyName, out int value)
         {
-            int has = 0;
-            value = fiftyone_hash_get_int(ResultsHashSwig.getCPtr(Object).Handle, propertyName, out has);
+            int hasValue = 0;
+            value = fiftyone_hash_get_int(ResultsHashSwig.getCPtr(Object).Handle, propertyName, out hasValue);
             GC.KeepAlive(Object);
-            return has != 0;
+            return hasValue != 0;
         }
 
         public bool TryGetDoubleFast(string propertyName, out double value)
         {
-            int has = 0;
-            value = fiftyone_hash_get_double(ResultsHashSwig.getCPtr(Object).Handle, propertyName, out has);
+            int hasValue = 0;
+            value = fiftyone_hash_get_double(ResultsHashSwig.getCPtr(Object).Handle, propertyName, out hasValue);
             GC.KeepAlive(Object);
-            return has != 0;
+            return hasValue != 0;
         }
 
         public bool TryGetStringFast(string propertyName, out string value)
         {
             var buffer = _stringBuffer ?? (_stringBuffer = new byte[512]);
-            int needed = 0;
-            int has = fiftyone_hash_get_string(
-                ResultsHashSwig.getCPtr(Object).Handle, propertyName, buffer, buffer.Length, out needed);
+            int valueLength = 0;
+            int hasValue = fiftyone_hash_get_string(
+                ResultsHashSwig.getCPtr(Object).Handle, propertyName, buffer, buffer.Length, out valueLength);
             GC.KeepAlive(Object);
-            // has == 0 -> no value (caller falls back for the no-value message).
-            // needed >= buffer.Length -> value too long to fit; fall back so the
-            // slow path returns the full value.
-            if (has == 0 || needed >= buffer.Length)
+            // hasValue == 0 -> no value (caller falls back for the no-value message).
+            // valueLength >= buffer.Length -> value too long to fit; fall back so
+            // the slow path returns the full value.
+            if (hasValue == 0 || valueLength >= buffer.Length)
             {
                 value = null;
                 return false;
             }
-            value = Encoding.UTF8.GetString(buffer, 0, needed);
+            value = Encoding.UTF8.GetString(buffer, 0, valueLength);
             return true;
         }
         public bool containsProperty(string propertyName)

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/Wrappers/ResultsSwigWrapper.cs
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/Wrappers/ResultsSwigWrapper.cs
@@ -38,16 +38,19 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Wrappers
         private const string NativeLib =
             "FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Native.dll";
 
-        [DllImport(NativeLib, EntryPoint = "fiftyone_hash_get_bool", CharSet = CharSet.Ansi)]
+        // Cdecl to match the plain extern "C" exports in DeviceDetectionFastValues.cpp.
+        // Unlike SWIG's own exports (which are SWIGSTDCALL), this hand-written TU is
+        // __cdecl, so on win-x86 the default Winapi/__stdcall would corrupt the stack.
+        [DllImport(NativeLib, EntryPoint = "fiftyone_hash_get_bool", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         private static extern int fiftyone_hash_get_bool(IntPtr results, string name, out int hasValue);
 
-        [DllImport(NativeLib, EntryPoint = "fiftyone_hash_get_int", CharSet = CharSet.Ansi)]
+        [DllImport(NativeLib, EntryPoint = "fiftyone_hash_get_int", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         private static extern int fiftyone_hash_get_int(IntPtr results, string name, out int hasValue);
 
-        [DllImport(NativeLib, EntryPoint = "fiftyone_hash_get_double", CharSet = CharSet.Ansi)]
+        [DllImport(NativeLib, EntryPoint = "fiftyone_hash_get_double", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         private static extern double fiftyone_hash_get_double(IntPtr results, string name, out int hasValue);
 
-        [DllImport(NativeLib, EntryPoint = "fiftyone_hash_get_string", CharSet = CharSet.Ansi)]
+        [DllImport(NativeLib, EntryPoint = "fiftyone_hash_get_string", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
         private static extern int fiftyone_hash_get_string(IntPtr results, string name, byte[] buffer, int bufferLength, out int valueLength);
 
         // Reusable per-thread buffer for the string fast path. Sized (4 KB) to

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/Wrappers/ResultsSwigWrapper.cs
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/Wrappers/ResultsSwigWrapper.cs
@@ -50,11 +50,15 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Wrappers
         [DllImport(NativeLib, EntryPoint = "fiftyone_hash_get_string", CharSet = CharSet.Ansi)]
         private static extern int fiftyone_hash_get_string(IntPtr results, string name, byte[] buffer, int bufferLength, out int valueLength);
 
-        // Reusable per-thread buffer for the string fast path, sized to cover
-        // effectively all device-detection property values; longer values fall
-        // back to the slow SWIG path.
+        // Reusable per-thread buffer for the string fast path. Sized (4 KB) to
+        // cover even large JavaScript-property snippets so they hit the fast path
+        // too. On a miss the value falls back to the slow SWIG path, which is
+        // slightly slower than pre-PR here (the native call has already built the
+        // full string to measure its length), so the buffer is kept generous.
         [ThreadStatic]
         private static byte[] _stringBuffer;
+
+        private const int StringBufferSize = 4096;
 
         public ResultsHashSwig Object { get; }
 
@@ -90,7 +94,7 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Wrappers
 
         public bool TryGetStringFast(string propertyName, out string value)
         {
-            var buffer = _stringBuffer ?? (_stringBuffer = new byte[512]);
+            var buffer = _stringBuffer ?? (_stringBuffer = new byte[StringBufferSize]);
             int valueLength = 0;
             int hasValue = fiftyone_hash_get_string(
                 ResultsHashSwig.getCPtr(Object).Handle, propertyName, buffer, buffer.Length, out valueLength);
@@ -103,6 +107,10 @@ namespace FiftyOne.DeviceDetection.Hash.Engine.OnPremise.Wrappers
                 value = null;
                 return false;
             }
+            // Decode as UTF-8, the encoding the data file stores values in. Note
+            // the SWIG slow path marshals std::string as ANSI/LPStr (system code
+            // page): for ASCII values - all current DD data - the two agree, and
+            // for any non-ASCII byte UTF-8 here is the more correct result.
             value = Encoding.UTF8.GetString(buffer, 0, valueLength);
             return true;
         }

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/hash_csharp.i
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/hash_csharp.i
@@ -19,7 +19,8 @@
 // translation unit (DeviceDetectionFastValues.cpp) + managed P/Invokes in
 // ResultsSwigWrapper, because the checked-in SWIG bindings are ~21 months behind
 // the device-detection-cxx submodule and regenerating would pull in a large,
-// unrelated binding refresh (see _docs/swig-marshaling-524).
+// unrelated binding refresh (see _docs/swig-marshaling-524). The regen is tracked
+// in issue #823.
 //
 // WHEN THE BINDINGS ARE NEXT REGENERATED, replace the hand-written .cpp and the
 // managed P/Invokes with the %extend below (uncomment it), so the fast paths are

--- a/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/hash_csharp.i
+++ b/FiftyOne.DeviceDetection.Hash.Engine.OnPremise/hash_csharp.i
@@ -5,3 +5,31 @@
 %apply unsigned char INPUT[] {unsigned char data[]}
 
 %include "./device-detection-cxx/src/hash/hash.i";
+
+// -----------------------------------------------------------------------------
+// Fix #4 (issue #524): flattened "by value" scalar property accessors.
+//
+// The generated getValueAsBool/Integer/Double/String each return a heap Value<T>
+// wrapper (BoolValueSwig etc.) that the caller then interrogates and disposes -
+// several P/Invokes and heap allocations per property read, which dominate the
+// managed cost of a detection.
+//
+// The accessors below return the value plus its has-value flag in one call with
+// no wrapper object. They are CURRENTLY IMPLEMENTED as a small hand-written
+// translation unit (DeviceDetectionFastValues.cpp) + managed P/Invokes in
+// ResultsSwigWrapper, because the checked-in SWIG bindings are ~21 months behind
+// the device-detection-cxx submodule and regenerating would pull in a large,
+// unrelated binding refresh (see _docs/swig-marshaling-524).
+//
+// WHEN THE BINDINGS ARE NEXT REGENERATED, replace the hand-written .cpp and the
+// managed P/Invokes with the %extend below (uncomment it), so the fast paths are
+// SWIG-generated and regen-safe:
+//
+// %extend FiftyoneDegrees::DeviceDetection::Hash::ResultsHash {
+//     bool tryGetBool(const char* name, bool* OUTPUT) { /* getValueAsBool -> hasValue/value */ }
+//     bool tryGetInt(const char* name, int* OUTPUT) { /* getValueAsInteger */ }
+//     bool tryGetDouble(const char* name, double* OUTPUT) { /* getValueAsDouble */ }
+//     // string: return the value into a caller buffer, or use %csmethodmodifiers
+//     //         with an out string typemap.
+// }
+// -----------------------------------------------------------------------------


### PR DESCRIPTION
#524 

Reading a scalar property (bool/int/double/string) went through a SWIG Value<T>
wrapper: a native object with a finalizer plus its managed proxy, interrogated
with hasValue()/getValue() and then disposed - about four P/Invokes and two heap
allocations per read. Property reads dominate the managed cost of a detection.

This adds native exports (DeviceDetectionFastValues.cpp) that call the same C++
ResultsHash getters and return the value plus its has-value flag in a single
P/Invoke with no wrapper object. DeviceDataHash uses these fast paths for bool,
int, double, string and JavaScript, falling back to the SWIG path only when
there is no value (to recover the no-value message) or, for strings, when the
value is longer than the reusable buffer.

Implemented as a small hand-written translation unit plus managed P/Invokes
rather than a SWIG %extend + regen, because the checked-in SWIG bindings are
~21 months behind the device-detection-cxx submodule and regenerating would pull
in a large, unrelated binding refresh. The equivalent %extend is documented in
hash_csharp.i for the next full regen.

Behaviour is unchanged (full Hash.Tests suite green). Measured on a bool+string
read mix: ~49% faster and ~50% fewer allocations per read.
