### PR TITLE
FIX: Don't log client-caused validation errors as errors (invalid TAC / NativeModel)

### DIFF
--- a/FiftyOne.DeviceDetection.PropertyKeyed/FlowElements/NativeEngine.cs
+++ b/FiftyOne.DeviceDetection.PropertyKeyed/FlowElements/NativeEngine.cs
@@ -54,11 +54,18 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.FlowElements
                 return true;
             }
 
+            // A malformed NativeModel is caller input, not a server fault, so
+            // it must not be logged at Error level - that path records it as an
+            // AppInsights exception (see cloud #201). Surface it through
+            // FlowData.Errors only: shouldLog: false suppresses the Error log
+            // while the error still reaches the response's errors array.
             data.AddError(
                 new ArgumentException(string.Format(
                     Messages.IncorrectNativeEvidence,
                     keyPropertyValue)),
-                data.Pipeline.GetElement<NativeEngine>());
+                data.Pipeline.GetElement<NativeEngine>(),
+                shouldThrow: true,
+                shouldLog: false);
             return false;
         }
     }

--- a/FiftyOne.DeviceDetection.PropertyKeyed/FlowElements/NativeEngine.cs
+++ b/FiftyOne.DeviceDetection.PropertyKeyed/FlowElements/NativeEngine.cs
@@ -54,11 +54,11 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.FlowElements
                 return true;
             }
 
-            // A malformed NativeModel is caller input, not a server fault, so
-            // it must not be logged at Error level - that path records it as an
-            // AppInsights exception (see cloud #201). Surface it through
-            // FlowData.Errors only: shouldLog: false suppresses the Error log
-            // while the error still reaches the response's errors array.
+            // A malformed NativeModel is caller input, not a server fault.
+            // Register it via FlowData.Errors without logging at Error level:
+            // the 2-arg overload defaults shouldLog to true, which logs the
+            // exception and can surface it as exception telemetry - noise for
+            // a client error.
             data.AddError(
                 new ArgumentException(string.Format(
                     Messages.IncorrectNativeEvidence,

--- a/FiftyOne.DeviceDetection.PropertyKeyed/FlowElements/TacEngine.cs
+++ b/FiftyOne.DeviceDetection.PropertyKeyed/FlowElements/TacEngine.cs
@@ -54,11 +54,18 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.FlowElements
                 return true;
             }
 
+            // A malformed TAC is caller input, not a server fault, so it must
+            // not be logged at Error level - that path records it as an
+            // AppInsights exception (see cloud #201). Surface it through
+            // FlowData.Errors only: shouldLog: false suppresses the Error log
+            // while the error still reaches the response's errors array.
             data.AddError(
                 new ArgumentException(string.Format(
                     Messages.IncorrectTacEvidence,
                     keyPropertyValue)),
-                data.Pipeline.GetElement<TacEngine>());
+                data.Pipeline.GetElement<TacEngine>(),
+                shouldThrow: true,
+                shouldLog: false);
             return false;
         }
     }

--- a/FiftyOne.DeviceDetection.PropertyKeyed/FlowElements/TacEngine.cs
+++ b/FiftyOne.DeviceDetection.PropertyKeyed/FlowElements/TacEngine.cs
@@ -54,11 +54,10 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.FlowElements
                 return true;
             }
 
-            // A malformed TAC is caller input, not a server fault, so it must
-            // not be logged at Error level - that path records it as an
-            // AppInsights exception (see cloud #201). Surface it through
-            // FlowData.Errors only: shouldLog: false suppresses the Error log
-            // while the error still reaches the response's errors array.
+            // A malformed TAC is caller input, not a server fault. Register it
+            // via FlowData.Errors without logging at Error level: the 2-arg
+            // overload defaults shouldLog to true, which logs the exception and
+            // can surface it as exception telemetry - noise for a client error.
             data.AddError(
                 new ArgumentException(string.Format(
                     Messages.IncorrectTacEvidence,

--- a/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/BaseEngineTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/BaseEngineTests.cs
@@ -98,8 +98,8 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Tests
         /// Asserts that nothing was logged at Error (or Critical) level during
         /// the current test. Client-caused validation errors must be surfaced
         /// via <see cref="IFlowData.Errors"/> without an Error-level log, since
-        /// an Error log carrying the exception is recorded as an AppInsights
-        /// exception (see cloud #201).
+        /// an Error log carrying the exception can be surfaced as exception
+        /// telemetry.
         /// </summary>
         protected static void AssertNoErrorLevelLog()
         {

--- a/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/BaseEngineTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/BaseEngineTests.cs
@@ -27,12 +27,14 @@ using FiftyOne.Pipeline.Core.FlowElements;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Linq;
 
 namespace FiftyOne.DeviceDetection.PropertyKeyed.Tests
 {
     public class BaseEngineTests<T> where T : IFlowElement
     {
         protected static ILoggerFactory _loggerFactory;
+        protected static CapturingLoggerProvider _capturedLogs;
         protected static T _engine;
         protected static IPipeline _pipeline;
         protected IFlowData _data;
@@ -50,7 +52,10 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Tests
         {
             var ddFile = Utils.GetFilePath(Constants.TAC_HASH_DATA_FILE_NAME).FullName;
 
-            _loggerFactory = LoggerFactory.Create(b => { });
+            _capturedLogs = new CapturingLoggerProvider();
+            _loggerFactory = LoggerFactory.Create(b => b
+                .AddProvider(_capturedLogs)
+                .SetMinimumLevel(LogLevel.Warning));
 
             // Build DeviceDetectionHashEngine first
             var hashEngine = new DeviceDetectionHashEngineBuilder(
@@ -80,12 +85,31 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Tests
 
         public virtual void TestInitialize()
         {
+            _capturedLogs?.Clear();
             _data = _pipeline.CreateFlowData();
         }
 
         public virtual void TestCleanup()
         {
             _data?.Dispose();
+        }
+
+        /// <summary>
+        /// Asserts that nothing was logged at Error (or Critical) level during
+        /// the current test. Client-caused validation errors must be surfaced
+        /// via <see cref="IFlowData.Errors"/> without an Error-level log, since
+        /// an Error log carrying the exception is recorded as an AppInsights
+        /// exception (see cloud #201).
+        /// </summary>
+        protected static void AssertNoErrorLevelLog()
+        {
+            var offending = _capturedLogs.Entries
+                .Where(e => e.Level >= LogLevel.Error)
+                .ToList();
+            Assert.IsEmpty(offending,
+                "Expected no Error-level log, but found: " +
+                string.Join("; ", offending.Select(e =>
+                    $"{e.Level} {e.Category}: {e.Exception?.Message}")));
         }
     }
 }

--- a/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/CapturingLoggerProvider.cs
+++ b/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/CapturingLoggerProvider.cs
@@ -48,7 +48,7 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Tests
     /// Minimal <see cref="ILoggerProvider"/> that records every log call so a
     /// test can assert on the level and exception that were logged. Used to
     /// verify that client-caused validation errors are not logged at Error
-    /// level (which would be recorded as an AppInsights exception).
+    /// level (which could be surfaced as exception telemetry).
     /// </summary>
     public sealed class CapturingLoggerProvider : ILoggerProvider
     {

--- a/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/CapturingLoggerProvider.cs
+++ b/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/CapturingLoggerProvider.cs
@@ -1,0 +1,115 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FiftyOne.DeviceDetection.PropertyKeyed.Tests
+{
+    /// <summary>
+    /// A single captured log call.
+    /// </summary>
+    public sealed class CapturedLog
+    {
+        public CapturedLog(LogLevel level, string category, Exception exception)
+        {
+            Level = level;
+            Category = category;
+            Exception = exception;
+        }
+
+        public LogLevel Level { get; }
+        public string Category { get; }
+        public Exception Exception { get; }
+    }
+
+    /// <summary>
+    /// Minimal <see cref="ILoggerProvider"/> that records every log call so a
+    /// test can assert on the level and exception that were logged. Used to
+    /// verify that client-caused validation errors are not logged at Error
+    /// level (which would be recorded as an AppInsights exception).
+    /// </summary>
+    public sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly List<CapturedLog> _entries = new List<CapturedLog>();
+        private readonly object _lock = new object();
+
+        public IReadOnlyList<CapturedLog> Entries
+        {
+            get { lock (_lock) { return _entries.ToList(); } }
+        }
+
+        public void Clear()
+        {
+            lock (_lock) { _entries.Clear(); }
+        }
+
+        public ILogger CreateLogger(string categoryName) =>
+            new CapturingLogger(categoryName, _entries, _lock);
+
+        public void Dispose() { }
+
+        private sealed class CapturingLogger : ILogger
+        {
+            private readonly string _category;
+            private readonly List<CapturedLog> _entries;
+            private readonly object _lock;
+
+            public CapturingLogger(
+                string category, List<CapturedLog> entries, object lockObj)
+            {
+                _category = category;
+                _entries = entries;
+                _lock = lockObj;
+            }
+
+            public IDisposable BeginScope<TState>(TState state) =>
+                NullScope.Instance;
+
+            // Always enabled so a regression that re-introduces the Error log
+            // is captured rather than filtered out.
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception exception,
+                Func<TState, Exception, string> formatter)
+            {
+                lock (_lock)
+                {
+                    _entries.Add(
+                        new CapturedLog(logLevel, _category, exception));
+                }
+            }
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new NullScope();
+            public void Dispose() { }
+        }
+    }
+}

--- a/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/NativeKeyedEngineTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/NativeKeyedEngineTests.cs
@@ -68,8 +68,8 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Tests
         /// <summary>
         /// An invalid NativeModel is caller input, so it must be surfaced via
         /// <see cref="FiftyOne.Pipeline.Core.Data.IFlowData.Errors"/> without
-        /// being logged at Error level - an Error log carrying the exception is
-        /// recorded as an AppInsights exception (see cloud #201).
+        /// being logged at Error level - an Error log carrying the exception
+        /// can be surfaced as exception telemetry.
         /// </summary>
         [TestMethod]
         [DataRow("X")]

--- a/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/NativeKeyedEngineTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/NativeKeyedEngineTests.cs
@@ -1,0 +1,85 @@
+/* *********************************************************************
+ * This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+ * Copyright 2026 51 Degrees Mobile Experts Limited, Davidson House,
+ * Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+ *
+ * This Original Work is licensed under the European Union Public Licence
+ * (EUPL) v.1.2 and is subject to its terms as set out below.
+ *
+ * If a copy of the EUPL was not distributed with this file, You can obtain
+ * one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * The 'Compatible Licences' set out in the Appendix to the EUPL (as may be
+ * amended by the European Commission) shall be deemed incompatible for
+ * the purposes of the Work and the provisions of the compatibility
+ * clause in Article 5 of the EUPL shall not apply.
+ *
+ * If using the Work as, or as part of, a network application, by
+ * including the attribution notice(s) required under Article 5 of the EUPL
+ * in the end user terms of the application under an appropriate heading,
+ * such notice(s) shall fulfill the requirements of that article.
+ * ********************************************************************* */
+
+using FiftyOne.DeviceDetection.PropertyKeyed.FlowElements;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FiftyOne.DeviceDetection.PropertyKeyed.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="NativeEngine"/> with NativeModel configuration.
+    /// </summary>
+    [TestClass]
+    public class NativeConfiguredEngineTests : BaseEngineTests<NativeEngine>
+    {
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context) =>
+            ClassInitializeInternal(
+                context,
+                () => new NativeEngineBuilder(_loggerFactory).Build());
+
+        [ClassCleanup]
+        public static void ClassCleanup() => ClassCleanupInternal();
+
+        [TestInitialize]
+        public override void TestInitialize()
+        {
+            base.TestInitialize();
+        }
+
+        [TestCleanup]
+        public override void TestCleanup()
+        {
+            base.TestCleanup();
+        }
+
+        /// <summary>
+        /// A NativeModel that is too short must add an error.
+        /// </summary>
+        [TestMethod]
+        [DataRow("X")]
+        public void InvalidNativeModel_AddsError(string nativeModel)
+        {
+            _data.AddEvidence("query.nativemodel", nativeModel);
+            _data.Process();
+            Assert.IsNotNull(_data.Errors,
+                "Expected an error for invalid NativeModel.");
+        }
+
+        /// <summary>
+        /// An invalid NativeModel is caller input, so it must be surfaced via
+        /// <see cref="FiftyOne.Pipeline.Core.Data.IFlowData.Errors"/> without
+        /// being logged at Error level - an Error log carrying the exception is
+        /// recorded as an AppInsights exception (see cloud #201).
+        /// </summary>
+        [TestMethod]
+        [DataRow("X")]
+        public void InvalidNativeModel_DoesNotLogError(string nativeModel)
+        {
+            _data.AddEvidence("query.nativemodel", nativeModel);
+            _data.Process();
+            Assert.IsNotNull(_data.Errors,
+                "Expected an error for invalid NativeModel.");
+            AssertNoErrorLevelLog();
+        }
+    }
+}

--- a/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/TacKeyedEngineTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/TacKeyedEngineTests.cs
@@ -88,8 +88,8 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Tests
         /// <summary>
         /// An invalid TAC is caller input, so it must be surfaced via
         /// <see cref="FiftyOne.Pipeline.Core.Data.IFlowData.Errors"/> without
-        /// being logged at Error level - an Error log carrying the exception is
-        /// recorded as an AppInsights exception (see cloud #201).
+        /// being logged at Error level - an Error log carrying the exception
+        /// can be surfaced as exception telemetry.
         /// </summary>
         [TestMethod]
         [DataRow("1234")]

--- a/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/TacKeyedEngineTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.PropertyKeyed.Tests/TacKeyedEngineTests.cs
@@ -86,6 +86,25 @@ namespace FiftyOne.DeviceDetection.PropertyKeyed.Tests
         }
 
         /// <summary>
+        /// An invalid TAC is caller input, so it must be surfaced via
+        /// <see cref="FiftyOne.Pipeline.Core.Data.IFlowData.Errors"/> without
+        /// being logged at Error level - an Error log carrying the exception is
+        /// recorded as an AppInsights exception (see cloud #201).
+        /// </summary>
+        [TestMethod]
+        [DataRow("1234")]
+        [DataRow("ABCDEFGH")]
+        [DataRow("123456789")]
+        public void InvalidTac_DoesNotLogError(string tac)
+        {
+            _data.AddEvidence("query.tac", tac);
+            _data.Process();
+            Assert.IsNotNull(_data.Errors,
+                "Expected an error for invalid TAC.");
+            AssertNoErrorLevelLog();
+        }
+
+        /// <summary>
         /// No evidence — engine is not processed.
         /// </summary>
         [TestMethod]


### PR DESCRIPTION
## Problem

`TacEngine.Validate` and `NativeEngine.Validate` register a malformed-input error with the 2-argument `IFlowData.AddError(ex, element)` overload, which defaults `shouldLog: true`. `FlowData.AddError` then logs the exception at **Error** level. An invalid `TAC` or `NativeModel` is client input, not a server fault, so this produces misleading Error-level logs (and, where a logging provider forwards them, exception telemetry) for something that has not actually failed.

## Fix

Use the 4-argument `AddError` overload with `shouldLog: false`. The error is still surfaced via `FlowData.Errors`; it is simply no longer logged at Error level. `shouldThrow` is left `true`, matching the previous default.

## Tests

Adds a capturing-logger test harness (`CapturingLoggerProvider` + `AssertNoErrorLevelLog`) and asserts that invalid input still adds an error but emits no Error-level log, for both engines.