### PR TITLE
FIX: Bump device-detection-cxx and align tests to unified result shape

### DIFF
--- a/Tests/FiftyOne.DeviceDetection.Hash.Tests/Data/DataValidatorHash.cs
+++ b/Tests/FiftyOne.DeviceDetection.Hash.Tests/Data/DataValidatorHash.cs
@@ -75,15 +75,15 @@ namespace FiftyOne.DeviceDetection.Hash.Tests.Data
                                 " 'header.user-agent'.", value.NoValueMessage);
                         } else
                         {
-                            // The documentation URL may have tracking query
-                            // parameters (e.g. utm_*) appended to it by the
-                            // data file, so only check the message up to and
-                            // including the base URL rather than an exact match.
-                            Assert.StartsWith("No matching profiles could be " +
-                                "found for the supplied evidence. A 'best " +
-                                "guess' can be returned by configuring more " +
-                                "lenient matching rules. See " +
-                                "https://51degrees.com/documentation/_device_detection__features__false_positive_control.html",
+                            // A User-Agent was supplied but nothing matched.
+                            // Since device-detection-cxx #362 removed the
+                            // single-User-Agent fast path, detection no longer
+                            // produces one coalesced result for this case, so
+                            // no result is selected for the property and the
+                            // reason reported is NO_RESULT_FOR_PROPERTY rather
+                            // than NO_MATCHED_NODES.
+                            Assert.AreEqual("None of the results contain a " +
+                                "value for the requested property.",
                                 value.NoValueMessage);
                         }
                     }
@@ -95,9 +95,25 @@ namespace FiftyOne.DeviceDetection.Hash.Tests.Data
                 Assert.AreEqual("0-0-0-0", elementData.DeviceId.Value);
             }
 
-            var validKeys = data.GetEvidence().AsDictionary().Keys.Where(
-                k => _engine.EvidenceKeyFilter.Include(k)).Count();
-            Assert.HasCount(validKeys, elementData.UserAgents.Value);
+            // Since the detection result shape was unified in
+            // device-detection-cxx (issue #362), the number of results - and
+            // therefore the number of matched User-Agents - is determined by
+            // the components the engine can populate, not by how many evidence
+            // keys were supplied. Supplying redundant evidence no longer
+            // changes it. The exact number depends on which components the data
+            // file makes available, so assert the bound rather than a fixed
+            // value, and that valid evidence produces at least one result.
+            var matchedUserAgents = elementData.UserAgents.Value;
+            Assert.IsLessThanOrEqualTo(
+                _engine.Components.Count(),
+                matchedUserAgents.Count(),
+                "There should be no more matched User-Agents than there are " +
+                "components populated by the engine.");
+            if (validEvidence)
+            {
+                Assert.IsNotEmpty(matchedUserAgents,
+                    "Valid evidence should produce at least one result.");
+            }
         }
 
         public void ValidateProfileIds(IFlowData data, string[] profileIds)

--- a/Tests/FiftyOne.DeviceDetection.TestHelpers/Data/ValueTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.TestHelpers/Data/ValueTests.cs
@@ -54,7 +54,19 @@ namespace FiftyOne.DeviceDetection.TestHelpers.Data
                         .Process();
                 var elementData = data.Get(wrapper.GetEngine().ElementDataKey);
                 IDeviceData device = (IDeviceData)elementData;
-                Assert.HasCount(1, device.UserAgents.Value);
+                // Since the detection result shape was unified in
+                // device-detection-cxx (issue #362), a single User-Agent
+                // produces one result - and so one matched User-Agent - per
+                // component the engine populates, rather than exactly one
+                // overall. The number depends on the data file, so assert the
+                // bound and validate every matched substring below.
+                Assert.IsNotEmpty(device.UserAgents.Value,
+                    "At least one matched User-Agent should be returned.");
+                Assert.IsLessThanOrEqualTo(
+                    wrapper.Components.Count(),
+                    device.UserAgents.Value.Count(),
+                    "There should be no more matched User-Agents than there " +
+                    "are components populated by the engine.");
                 foreach (var matchedUa in device.UserAgents.Value)
                 {
                     foreach (var substring in matchedUa.Split('_', '{', '}'))


### PR DESCRIPTION
Relates to #TASK

Picks up the `device-detection-cxx` change that unified the detection result
shape (51Degrees/device-detection-cxx#362, merged in
51Degrees/device-detection-cxx#385) and updates the .NET test expectations that
encoded the removed fast path.

The submodule bump and the test updates have to land together: the new
expectations do not hold against the previous native library, and the old ones
do not hold against the new one.

## Why the nightly failed

The nightly on #836 reported 16 failures in
`FiftyOne.DeviceDetection.Hash.Tests` across three test methods
([run](https://github.com/51Degrees/device-detection-dotnet/actions/runs/29978626985/job/89115951419)).
Both causes are the intended consequence of removing the single-User-Agent
fast path, not new defects:

1. **`Process_Hash_Core_CaseInsensitiveKeys`, `Values_Hash_Core_MatchedUserAgents`**
   — `DataValidatorHash` asserted one matched User-Agent *per accepted evidence
   key*, and `ValueTests.MatchedUserAgents` asserted exactly one. That coupling
   between evidence cardinality and result shape is precisely what #362
   removed: the number of results is now driven by the components the engine
   populates, so a single User-Agent yields 4 rather than 1.

2. **`Process_Hash_Core_EmptyUserAgent`** — with the fast path gone, a
   User-Agent no longer produces a single coalesced result, so
   `getResultForPropertyIndex`'s `count == 1` shortcut no longer applies and no
   result is selected for the property. The reported reason changes from
   `NO_MATCHED_NODES` to `NO_RESULT_FOR_PROPERTY`.

## Changes

- Bump `device-detection-cxx` to `c7b2822` (includes #362 / #385).
- `DataValidatorHash` — replace the per-evidence-key count with a bound
  (no more matched User-Agents than components populated by the engine) plus
  "valid evidence yields at least one result"; update the no-match message.
- `ValueTests.MatchedUserAgents` — same bound. The per-entry check that every
  matched substring really occurs at the expected offset in the original
  User-Agent is unchanged; that is the substantive assertion.

The counts are deliberately asserted as a bound rather than a fixed number.
Locally the engine reports 5 components but 4 results, because the contract is
"components that have available properties" — pinning an exact value would
couple the tests to the data file, and deriving it in .NET means allocating
disposable native metadata wrappers on a hot test path.

## Verification

Rebuilt the native engine against the new submodule and ran the Hash suite on
Windows x64:

- Before: 16 failed / 134 passed
- After: **0 failed / 150 passed / 6 skipped**

Note for anyone reproducing locally: the test project only copies the native
library when `Platform != AnyCPU`, so build and run with `-p:Platform=x64`
after rebuilding it. A default `dotnet test` silently reuses a stale native
DLL and shows the old behaviour.

## Behaviour change to be aware of

#362 is an observable change for on-premise consumers, and this PR is where it
reaches .NET:

- The number of entries in `UserAgents` (and match metrics derived from the
  result list) is now determined by the data file's components, not by how many
  evidence pairs were supplied. Redundant evidence no longer changes it.
- With `allowUnmatched` enabled, components with no matched profile are filled
  with each component's default profile, matching evidence-based processing.
- The no-value message for a supplied-but-unmatched User-Agent is now the
  generic "None of the results contain a value for the requested property."
  rather than the more actionable "No matching profiles could be found…"
  wording. Worth a follow-up on `device-detection-cxx` to restore the better
  diagnostic; it is a message-quality regression rather than a functional one.

Please call these out in the release notes.

## Supersedes

Replaces the automated submodule PR #836, which cannot go green on its own
because it carries the bump without the matching test updates. Close #836 when
this merges.
