### PR TITLE
FIX: Run example test assemblies one at a time

### DIFF
--- a/ci/run-integration-tests.ps1
+++ b/ci/run-integration-tests.ps1
@@ -113,7 +113,43 @@ Get-ChildItem -Path $ExamplesRepo -Recurse -File -Filter '*.csproj' | ForEach-Ob
 Write-Host "Building Examples Project..."
 & $ExamplesRepo/ci/build-project.ps1 -RepoName $ExamplesRepo -Name $Name -Configuration $Configuration -Arch $Arch -BuildMethod $BuildMethod
 Write-Host "Testing Examples Project..."
-./dotnet/run-integration-tests.ps1 -RepoName $ExamplesRepo -Name $Name -Configuration $Configuration -Arch $Arch -BuildMethod $BuildMethod -DirNameFormatForDotnet "*" -DirNameFormatForNotDotnet "*" -Filter ".*\.sln"
+# Run one test assembly at a time. Passing the solution instead made VSTest
+# start a test host per project simultaneously, and the three web example test
+# projects then raced for the fixed Kestrel ports declared in the examples repo
+# (Examples/ExampleBase/Constants.cs: 5101 HTTP, 5001 and 5002 HTTPS). Whichever
+# host bound second failed with EADDRINUSE, which surfaced as a TestCleanup
+# exception on every test in that assembly. See issue #866.
+#
+# FiftyOne.DeviceDetection.Example.Tests.Web holds the shared base classes and
+# declares no tests of its own, so it is excluded - dotnet test reports "No test
+# is available" and exits non-zero for an assembly it finds nothing in.
+#
+# The default DirNameFormat values are kept so that only the build output under
+# 'bin' is considered. Overriding them to '*', as this call used to, also matched
+# the intermediate copy under 'obj' and would run every assembly twice.
+#
+# Trade-off: naming assemblies rather than the solution bypasses MSBuild, so the
+# RunSettingsFilePath that Tests.Cloud and Tests.OnPremise point at
+# (Tests/test.runsettings, MSTest TestTimeout 60s) no longer applies to them; the
+# runner's --blame-hang-timeout of 5m is the remaining guard. common-ci cannot
+# carry it either way today - dotnet/run-unit-tests.ps1 looks for test.runsettings
+# with [IO.Path]::Exists, which resolves against the process directory and not the
+# repository it has pushed into, and dotnet/run-integration-tests.ps1 does not
+# forward -BlameHangTimeout. Both belong in common-ci.
+$exampleTestAssemblies = '.*Example\.Tests\.(?!Web\.dll$).*\.dll$'
+
+# A filter that matches nothing leaves the run green with no tests executed,
+# which is how the Selenium tests went unnoticed until examples PR #920. Fail
+# loudly instead, and record what is about to run.
+$exampleTestAssemblyFiles = Get-ChildItem -Path $ExamplesRepo -Recurse -File |
+    Where-Object { $_.DirectoryName -like '*bin*' -and $_.Name -match $exampleTestAssemblies }
+if (-not $exampleTestAssemblyFiles) {
+    throw "No example test assemblies under '$ExamplesRepo' matched '$exampleTestAssemblies'."
+}
+Write-Host "Example test assemblies to run:"
+$exampleTestAssemblyFiles | ForEach-Object { Write-Host "  $($_.FullName)" }
+
+./dotnet/run-integration-tests.ps1 -RepoName $ExamplesRepo -Name $Name -Configuration $Configuration -Arch $Arch -BuildMethod $BuildMethod -Filter $exampleTestAssemblies
 
 Copy-Item $ExamplesRepo/test-results $RepoName -Recurse
 


### PR DESCRIPTION
Fixes #866.

## Problem

`ci/run-integration-tests.ps1` ran the examples tests with `-Filter ".*\.sln"`, so `dotnet test` was invoked against the solution and VSTest started one test host per project concurrently — all six assemblies began within eight seconds of each other. Three of them (`Web.Cloud`, `Web.OnPremise`, `Web.Cloud.ClientOnly`) each start their own Kestrel on the fixed ports declared in the examples repo's `Examples/ExampleBase/Constants.cs`: 5101 HTTP, 5001 and 5002 HTTPS. Whichever host bound second failed with `EADDRINUSE`.

`SeleniumTestsBase.TestCleanup` calls `ServerTask.Wait()`, which rethrows the bind failure as an `AggregateException`. A throwing `[TestCleanup]` escalates the outcome to Failed, so tests that had only reported `Assert.Inconclusive` appeared as failures. All 42 failures on `Ubuntu_x64_Release` trace to this one cause; both macOS legs failed the same way.

This surfaced on 2026-09-01 because examples PR 51Degrees/device-detection-dotnet-examples#920 fixed the non-static `[ClassInitialize]` that had made MSTest drop every Selenium class at discovery. Those newly running tests are the ones that start a server, so nothing bound the ports before. PR 920 exposed a latent conflict rather than regressing anything.

## Change

Filter on the test assemblies instead of the solution, so common-ci's runner invokes `dotnet test` once per assembly and the servers never overlap.

- `FiftyOne.DeviceDetection.Example.Tests.Web` is excluded. It holds only shared base classes and declares no tests, and `dotnet test` reports "No test is available" and exits non-zero for an assembly it finds nothing in.
- The `-DirNameFormatForDotnet "*"` / `-DirNameFormatForNotDotnet "*"` overrides are dropped so the defaults (`*bin*`, `*\bin\*`) apply. With `"*"` the intermediate copy under `obj` matched as well.
- A pre-flight check throws when the filter matches no assembly, so a renamed or newly added test project cannot leave the step green with nothing run — the same silent-skip failure mode that hid the Selenium tests.

Passing the solution also ran the whole suite twice, because `.*\.sln` matched both `FiftyOne.DeviceDetection.Examples.sln` and `FiftyOne.DeviceDetection.Examples.Core.slnf`. That duplication is gone.

## Windows legs now actually run the tests

`Windows_x64_Release` and `Windows_x86_Release` use `BuildMethod` `msbuild`, so common-ci calls `vstest.console.exe` on the solution. VSTest cannot read a solution file: it logged "A total of 1 test files matched the specified pattern", ran zero tests and exited 0. The example tests have never run on Windows. They will now, so the first nightly may surface pre-existing failures that the no-op has been hiding.

## Known trade-off

Naming assemblies bypasses MSBuild, so the `RunSettingsFilePath` that `Tests.Cloud` and `Tests.OnPremise` point at (`Tests/test.runsettings`, MSTest `TestTimeout` 60s) no longer applies to them; the runner's 5-minute `--blame-hang-timeout` is the remaining guard. The three web assemblies never had it. This cannot be fixed from this repository: `common-ci/dotnet/run-unit-tests.ps1` detects `test.runsettings` with `[IO.Path]::Exists`, which resolves against the process directory rather than the repository it has `Push-Location`ed into, and `common-ci/dotnet/run-integration-tests.ps1` does not forward `-BlameHangTimeout`. Follow-up for common-ci: switch that check to `Test-Path` and forward the timeout.

## Verification

- The regex selects exactly the five real test assemblies over a real checkout and excludes the shared base, with no `obj` or `ref` leakage.
- `[Parser]::ParseFile` reports the script parses clean; the guard trips correctly on a tree with no test assemblies.
- The `dotnet test <assembly.dll>` pattern with the default `*bin*` directory filter is already how this repository's own `Build and Test` job runs its unit tests.
