### PR TITLE
FIX: Report every example test assembly, not just the first

### DIFF
--- a/ci/run-integration-tests.ps1
+++ b/ci/run-integration-tests.ps1
@@ -149,7 +149,21 @@ if (-not $exampleTestAssemblyFiles) {
 Write-Host "Example test assemblies to run:"
 $exampleTestAssemblyFiles | ForEach-Object { Write-Host "  $($_.FullName)" }
 
-./dotnet/run-integration-tests.ps1 -RepoName $ExamplesRepo -Name $Name -Configuration $Configuration -Arch $Arch -BuildMethod $BuildMethod -Filter $exampleTestAssemblies
+# common-ci's runner is written to keep going after a failing assembly: it records
+# the failure, carries on, and calls Write-Error once the loop is done. The
+# $PSNativeCommandUseErrorActionPreference set at the top of this script is
+# inherited into it though, so the first non-zero dotnet test / vstest.console.exe
+# throws and the remaining assemblies never run. That went unnoticed while the
+# solution was passed as a single invocation; with one invocation per assembly it
+# hides real failures - Windows_x64 stopped after three of the five assemblies in
+# run 33748849603. Turn it off for this call only. The step still fails, because
+# the runner's closing Write-Error is terminating under $ErrorActionPreference.
+$PSNativeCommandUseErrorActionPreference = $false
+try {
+    ./dotnet/run-integration-tests.ps1 -RepoName $ExamplesRepo -Name $Name -Configuration $Configuration -Arch $Arch -BuildMethod $BuildMethod -Filter $exampleTestAssemblies
+} finally {
+    $PSNativeCommandUseErrorActionPreference = $true
+}
 
 Copy-Item $ExamplesRepo/test-results $RepoName -Recurse
 


### PR DESCRIPTION
Fixes #870.

Follow-up to #867, from nightly run 33748849603.

## Problem

#867 replaced one `dotnet test <solution>` invocation with one invocation per test assembly. That exposed an interaction that could not show up before: `ci/run-integration-tests.ps1` sets `$PSNativeCommandUseErrorActionPreference = $true` at the top, and PowerShell child scopes inherit it, so it is in force inside `common-ci/dotnet/run-unit-tests.ps1`.

That runner is written to keep going after a failing assembly — it records `$script:ok = $false`, continues the loop, and calls `Write-Error "Tests failed"` once every assembly has run. With the inherited preference the first non-zero `dotnet test` / `vstest.console.exe` throws instead, and the loop stops.

In run 33748849603, `Windows_x64_Release` ran three of the five assemblies and stopped:

```
NativeCommandExitException: dotnet/run-unit-tests.ps1:85
Program "vstest.console.exe" ended with non-zero exit code: 1 (0x00000001).
```

`FiftyOne.DeviceDetection.Example.Tests.Web.OnPremise` and `...Web.Cloud.ClientOnly` never ran, so the job reported only part of what was wrong.

## Change

Turn the preference off around that one call and restore it afterwards, so the runner does its own aggregation. Everything else in the script — `dotnet build`, `dotnet publish`, the package consumption fixture — keeps failing fast on a non-zero native command.

The step still fails when tests fail: `Write-Error` is terminating under `$ErrorActionPreference = "Stop"`, which the runner also inherits.

## Verification

A harness reproducing the same structure (outer script setting both preferences, inner script looping over a failing native command and calling `Write-Error` at the end):

| | assemblies run | exit code |
| --- | --- | --- |
| current | stops after the 1st | 1 |
| with this change | all 3 | 1 |

So the failure is still reported, it is just reported after every assembly has had a turn.
