### PR TITLE
Offer the stored string from on-premise device data

### DIFF
--- a/FiftyOne.DeviceDetection.Cloud/FiftyOne.DeviceDetection.Cloud.csproj
+++ b/FiftyOne.DeviceDetection.Cloud/FiftyOne.DeviceDetection.Cloud.csproj
@@ -66,7 +66,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FiftyOne.Pipeline.CloudRequestEngine" Version="4.5.97" />
+    <PackageReference Include="FiftyOne.Pipeline.CloudRequestEngine" Version="4.5.98" />
     <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 

--- a/FiftyOne.DeviceDetection.Data/Data/DeviceDataBaseOnPremise.cs
+++ b/FiftyOne.DeviceDetection.Data/Data/DeviceDataBaseOnPremise.cs
@@ -53,7 +53,8 @@ namespace FiftyOne.DeviceDetection.Shared.Data
     /// Base class used for all 51Degrees on-premise device data.
     /// See the <see href="https://github.com/51Degrees/specifications/blob/main/device-detection-specification/data-model.md">Specification</see>
     /// </summary>
-    public abstract class DeviceDataBaseOnPremise<TResult> : DeviceDataBase
+    public abstract class DeviceDataBaseOnPremise<TResult> : DeviceDataBase,
+        IProvidesValuesAsString
         where TResult : IDisposable
     {
         /// <summary>
@@ -316,6 +317,37 @@ namespace FiftyOne.DeviceDetection.Shared.Data
         /// <see cref="IAspectPropertyValue"/> instance.
         /// </returns>
         protected abstract IAspectPropertyValue<JavaScript> GetValueAsJavaScript(string propertyName);
+
+        #endregion
+
+        #region IProvidesValuesAsString
+        /// <summary>
+        /// Get the string value this instance has for the specified
+        /// property.
+        /// </summary>
+        /// <remarks>
+        /// The typed accessors have to answer in the type the property
+        /// declares, so a stored value that is not one of that type's
+        /// values has to become something. A Bool property storing
+        /// "Unknown" answers False, and the caller cannot tell that from
+        /// a stored "False". This is implemented explicitly so that the
+        /// stored string becomes reachable from outside the class whilst
+        /// <see cref="GetValueAsString(string)"/> keeps the signature and
+        /// the visibility it has always had, which means nothing that
+        /// derives from this class has to change.
+        /// </remarks>
+        /// <param name="propertyName">
+        /// The name of the property to get value for.
+        /// </param>
+        /// <returns>
+        /// A <see cref="string"/> wrapped in a
+        /// <see cref="IAspectPropertyValue"/> instance.
+        /// </returns>
+        IAspectPropertyValue<string> IProvidesValuesAsString.GetValueAsString(
+            string propertyName)
+        {
+            return GetValueAsString(propertyName);
+        }
 
         #endregion
 

--- a/FiftyOne.DeviceDetection.Data/FiftyOne.DeviceDetection.Shared.csproj
+++ b/FiftyOne.DeviceDetection.Data/FiftyOne.DeviceDetection.Shared.csproj
@@ -62,7 +62,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="FiftyOne.Pipeline.Engines.FiftyOne" Version="4.5.97" />
+    <PackageReference Include="FiftyOne.Pipeline.Engines.FiftyOne" Version="4.5.98" />
   </ItemGroup>
 
 </Project>

--- a/FiftyOne.DeviceDetection.PropertyKeyed/FiftyOne.DeviceDetection.PropertyKeyed.csproj
+++ b/FiftyOne.DeviceDetection.PropertyKeyed/FiftyOne.DeviceDetection.PropertyKeyed.csproj
@@ -60,7 +60,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FiftyOne.DeviceDetection.Hash.Engine.OnPremise\FiftyOne.DeviceDetection.Hash.Engine.OnPremise.csproj" />
-    <PackageReference Include="FiftyOne.Pipeline.Engines.FiftyOne" Version="4.5.97" />
+    <PackageReference Include="FiftyOne.Pipeline.Engines.FiftyOne" Version="4.5.98" />
   </ItemGroup>
 
 </Project>

--- a/FiftyOne.DeviceDetection.RobotsTxt.Cloud/FiftyOne.DeviceDetection.RobotsTxt.Cloud.csproj
+++ b/FiftyOne.DeviceDetection.RobotsTxt.Cloud/FiftyOne.DeviceDetection.RobotsTxt.Cloud.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FiftyOne.Pipeline.CloudRequestEngine" Version="4.5.97" />
+    <PackageReference Include="FiftyOne.Pipeline.CloudRequestEngine" Version="4.5.98" />
     <ProjectReference Include="..\FiftyOne.DeviceDetection.RobotsTxt\FiftyOne.DeviceDetection.RobotsTxt.csproj" />
   </ItemGroup>
 

--- a/FiftyOne.DeviceDetection.RobotsTxt/FiftyOne.DeviceDetection.RobotsTxt.csproj
+++ b/FiftyOne.DeviceDetection.RobotsTxt/FiftyOne.DeviceDetection.RobotsTxt.csproj
@@ -69,7 +69,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FiftyOne.Pipeline.Engines.FiftyOne" Version="4.5.97" />
+    <PackageReference Include="FiftyOne.Pipeline.Engines.FiftyOne" Version="4.5.98" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/FiftyOne.DeviceDetection.Cloud.Tests/FiftyOne.DeviceDetection.Cloud.Tests.csproj
+++ b/Tests/FiftyOne.DeviceDetection.Cloud.Tests/FiftyOne.DeviceDetection.Cloud.Tests.csproj
@@ -15,8 +15,8 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="FiftyOne.Common.TestHelpers" Version="5.1.8" />
-		<PackageReference Include="FiftyOne.Pipeline.Engines.TestHelpers" Version="4.5.97" />
-		<PackageReference Include="FiftyOne.Pipeline.Web" Version="4.5.97" />
+		<PackageReference Include="FiftyOne.Pipeline.Engines.TestHelpers" Version="4.5.98" />
+		<PackageReference Include="FiftyOne.Pipeline.Web" Version="4.5.98" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
 	</ItemGroup>
 

--- a/Tests/FiftyOne.DeviceDetection.RobotsTxt.Cloud.Tests/FiftyOne.DeviceDetection.RobotsTxt.Cloud.Tests.csproj
+++ b/Tests/FiftyOne.DeviceDetection.RobotsTxt.Cloud.Tests/FiftyOne.DeviceDetection.RobotsTxt.Cloud.Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FiftyOne.Common.TestHelpers" Version="5.1.8" />
-    <PackageReference Include="FiftyOne.Pipeline.Engines.TestHelpers" Version="4.5.97" />
+    <PackageReference Include="FiftyOne.Pipeline.Engines.TestHelpers" Version="4.5.98" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
   </ItemGroup>
 

--- a/Tests/FiftyOne.DeviceDetection.Tests.Core/Data/DeviceDataOnPremiseTests.cs
+++ b/Tests/FiftyOne.DeviceDetection.Tests.Core/Data/DeviceDataOnPremiseTests.cs
@@ -259,6 +259,65 @@ namespace FiftyOne.DeviceDetection.Tests.Core.Data
             TestAccessingValue(_testPropertyNameJavaScript, _testValueJavaScript);
         }
 
+        /// <summary>
+        /// Check that the stored string is reachable through
+        /// <see cref="IProvidesValuesAsString"/>, and that asking for it
+        /// does not change what the typed accessor answers.
+        /// </summary>
+        /// <remarks>
+        /// This is the point of the interface. A Bool property in a data
+        /// file can store a value that is not one of that type's values,
+        /// and device detection does exactly that, storing "Unknown" for
+        /// the properties the 51Degrees JavaScript fills in until it has
+        /// run. The typed accessor has to answer in its own type, so
+        /// without this a caller cannot tell that from a stored "False".
+        /// </remarks>
+        [TestMethod]
+        public void GetStringThroughTheInterface()
+        {
+            var asString = _results as IProvidesValuesAsString;
+            Assert.IsNotNull(
+                asString,
+                "On-premise device data should offer its stored strings.");
+
+            var value = asString.GetValueAsString(_testPropertyNameString);
+            Assert.IsTrue(value.HasValue);
+            Assert.AreEqual(_testValueString, value.Value);
+
+            // The typed accessor is untouched by the interface being
+            // there, which is what keeps this change from moving any
+            // existing caller.
+            var typed = _results[_testPropertyNameBool];
+            Assert.AreEqual(
+                _testValueBool, ((IAspectPropertyValue)typed).Value);
+        }
+
+        /// <summary>
+        /// A property the data does not hold reaches the caller the same
+        /// way through the interface as through the typed accessor, being
+        /// a <see cref="PropertyMissingException"/> rather than a value
+        /// that is empty or false.
+        /// </summary>
+        /// <remarks>
+        /// The interface adds a route to a value and changes nothing
+        /// about how an absent property is reported, which matters
+        /// because a caller that read a missing property as a value would
+        /// draw a conclusion from something this data file does not
+        /// carry.
+        /// </remarks>
+        [TestMethod]
+        public void GetStringThroughTheInterface_UnknownProperty()
+        {
+            var asString = _results as IProvidesValuesAsString;
+            Assert.IsNotNull(asString);
+
+            Assert.ThrowsExactly<PropertyMissingException>(
+                () => asString.GetValueAsString("NotAPropertyName"),
+                "A property the data does not hold should be reported as "
+                + "missing, in the same way as through any other "
+                + "accessor.");
+        }
+
         private void TestAccessingValue(string propertyName, object expectedResult)
         {
             var value = _results[propertyName];

--- a/Tools/GenerateConfig/GenerateConfig.csproj
+++ b/Tools/GenerateConfig/GenerateConfig.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.5.97" />
+    <PackageReference Include="FiftyOne.Pipeline.Web" Version="4.5.98" />
     <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 

--- a/performance-tests/performance-tests.csproj
+++ b/performance-tests/performance-tests.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FiftyOne.Pipeline.Web" Version="4.5.97" />
+		<PackageReference Include="FiftyOne.Pipeline.Web" Version="4.5.98" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.30" />
 	</ItemGroup>
 


### PR DESCRIPTION
Part one of two. Merges and releases **after** [pipeline-dotnet 404](https://github.com/51Degrees/pipeline-dotnet/pull/404), which adds the interface this implements.

## The problem

`DeviceDataHash` stores the string `Unknown` for `IsVisible` and `HasWebDriver` on any request the 51Degrees JavaScript has not run on. Its `GetValueAsBool` turns that into `false`, and both accessors are `protected`, so no consumer can tell "nobody measured whether the window was in view" from "the window was measured and was not in view".

Measured against the released Enterprise data file of 4 September 2026, with nothing but a Chrome 139 User-Agent:

```
property        indexer                 IProvidesValuesAsString
IsVisible       False (Boolean)         Unknown (String)
HasWebDriver    False (Boolean)         Unknown (String)
IsCrawler       False (Boolean)         False (String)
IsHeadless      False (Boolean)         False (String)
```

The first two were never measured. The last two were. Every consumer sees the same answer for all four.

## The change

One file, `FiftyOne.DeviceDetection.Data\Data\DeviceDataBaseOnPremise.cs`. The class declaration gains `IProvidesValuesAsString`, and the body gains an explicit implementation forwarding to the existing protected member.

It is implemented explicitly on purpose. The `protected abstract GetValueAsString` keeps its signature and its visibility, so `DeviceDataHash` and the test double need no change at all, and nothing outside gains a public method it did not ask for. The capability is reachable only through the interface, by a caller that has asked for it.

## What this does not change

`GetValueAsBool` still answers `False`, the public indexer still answers `False`, and a cloud response still carries `"isvisible": false`. No existing caller sees any difference. This is additive.

## Tests

Two added to `Tests\FiftyOne.DeviceDetection.Tests.Core\Data\DeviceDataOnPremiseTests.cs`:

- `GetStringThroughTheInterface` reads a property through the interface and checks the stored string comes back, then reads another through the indexer and checks the typed value is unchanged.
- `GetStringThroughTheInterface_UnknownProperty` checks a property the data does not hold is still reported as missing, rather than answering an empty string, because a caller reading a missing property as a value would draw a conclusion from something the file does not carry.

`dotnet test --filter FullyQualifiedName~DeviceDataOnPremiseTests` gives 8 passed, 0 failed, against a baseline of 6.

## For the reviewer

The pipeline package reference in this repository is a published version, so this branch cannot build until 404 is released. It was verified locally by pointing those references at a working copy of pipeline-dotnet, which is deliberately **not** in this branch, and the proof above was produced from that build. So expect CI here to fail until the pipeline release lands, and please do not merge before it does.
